### PR TITLE
Fix: add fallback to GitHub username

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,0 +1,6 @@
+return {
+	default = {
+		lpath = "lua/?.lua;lua/?/init.lua",
+		helper = "spec/support/vim_stub.lua",
+	},
+}

--- a/lua/atlas/pulls/providers/github/api/normalizer.lua
+++ b/lua/atlas/pulls/providers/github/api/normalizer.lua
@@ -8,7 +8,8 @@ function M.normalize_pr(raw)
 	local author_id = ""
 	if type(raw.author) == "table" then
 		author_login = tostring(raw.author.login or "")
-		local name = tostring(raw.author.name or "")
+		local raw_name = raw.author.name
+		local name = (raw_name ~= nil and raw_name ~= vim.NIL) and tostring(raw_name) or ""
 		author_name = name ~= "" and name or author_login
 		author_id = tostring(raw.author.id or "")
 	end

--- a/spec/github_normalizer_spec.lua
+++ b/spec/github_normalizer_spec.lua
@@ -1,0 +1,50 @@
+local normalizer = require("atlas.pulls.providers.github.api.normalizer")
+
+local function base_raw()
+	return {
+		number = 42,
+		title = "My PR",
+		body = "Description",
+		state = "OPEN",
+		isDraft = false,
+		headRefName = "feature",
+		headRefOid = "abc123",
+		baseRefName = "main",
+		baseRefOid = "def456",
+		createdAt = "2024-01-01T00:00:00Z",
+		updatedAt = "2024-01-02T00:00:00Z",
+		url = "https://github.com/owner/repo/pull/42",
+		repository = { name = "repo", nameWithOwner = "owner/repo" },
+		author = { login = "octocat", name = "Octo Cat", id = "1" },
+	}
+end
+
+describe("normalize_pr author.name", function()
+	it("uses author.name when it is a normal string", function()
+		local raw = base_raw()
+		raw.author.name = "Octo Cat"
+		local pr = normalizer.normalize_pr(raw)
+		assert.are.equal("Octo Cat", pr.author.name)
+	end)
+
+	it("falls back to login when author.name is nil", function()
+		local raw = base_raw()
+		raw.author.name = nil
+		local pr = normalizer.normalize_pr(raw)
+		assert.are.equal("octocat", pr.author.name)
+	end)
+
+	it("falls back to login when author.name is vim.NIL", function()
+		local raw = base_raw()
+		raw.author.name = vim.NIL
+		local pr = normalizer.normalize_pr(raw)
+		assert.are.equal("octocat", pr.author.name)
+	end)
+
+	it("falls back to login when author.name is an empty string", function()
+		local raw = base_raw()
+		raw.author.name = ""
+		local pr = normalizer.normalize_pr(raw)
+		assert.are.equal("octocat", pr.author.name)
+	end)
+end)

--- a/spec/keymaps_spec.lua
+++ b/spec/keymaps_spec.lua
@@ -1,9 +1,3 @@
-if _G.vim == nil then
-	_G.vim = {}
-end
-
-vim.env = vim.env or {}
-
 local config = require("atlas.config")
 local keymaps = require("atlas.core.keymaps")
 

--- a/spec/markdown_spec.lua
+++ b/spec/markdown_spec.lua
@@ -1,23 +1,3 @@
-if _G.vim == nil then
-	_G.vim = {
-		split = function(s, sep, opts)
-			local plain = opts and opts.plain
-			local result = {}
-			local from = 1
-			while true do
-				local start, finish = s:find(sep, from, plain)
-				if not start then
-					table.insert(result, s:sub(from))
-					break
-				end
-				table.insert(result, s:sub(from, start - 1))
-				from = finish + 1
-			end
-			return result
-		end,
-	}
-end
-
 local md = require("atlas.issues.providers.jira.converted.markdown")
 
 --- Helper: wraps content nodes in a full ADF doc

--- a/spec/repo_paths_spec.lua
+++ b/spec/repo_paths_spec.lua
@@ -1,32 +1,3 @@
-if _G.vim == nil then
-	_G.vim = {
-		env = { HOME = os.getenv("HOME") or "" },
-		fn = {
-			expand = function(x)
-				if x == "~" then
-					return os.getenv("HOME") or ""
-				end
-				return x
-			end,
-			fnamemodify = function(path, _)
-				return path
-			end,
-			isdirectory = function(_)
-				return 1
-			end,
-			stdpath = function(_)
-				return "/tmp"
-			end,
-			writefile = function(_, _, _)
-				return 0
-			end,
-		},
-		inspect = function(v)
-			return tostring(v)
-		end,
-	}
-end
-
 local checkout = require("atlas.core.git.checkout")
 
 describe("repo_paths", function()

--- a/spec/support/vim_stub.lua
+++ b/spec/support/vim_stub.lua
@@ -1,0 +1,57 @@
+-- Minimal stub for the `vim` global so specs can run outside Neovim via busted.
+-- Loaded once as a busted helper (--helper=spec/support/vim_stub.lua).
+-- Individual spec files no longer need their own `if _G.vim == nil then` blocks.
+
+if _G.vim ~= nil then
+	return
+end
+
+_G.vim = {
+	-- Sentinel used by the Neovim C layer for JSON null / GraphQL null values.
+	NIL = {},
+
+	-- vim.split(s, sep, {plain=true|false})
+	split = function(s, sep, opts)
+		local plain = opts and opts.plain
+		local result = {}
+		local from = 1
+		while true do
+			local start, finish = s:find(sep, from, plain)
+			if not start then
+				table.insert(result, s:sub(from))
+				break
+			end
+			table.insert(result, s:sub(from, start - 1))
+			from = finish + 1
+		end
+		return result
+	end,
+
+	-- vim.inspect / vim.fn stubs used by various modules
+	inspect = function(v)
+		return tostring(v)
+	end,
+
+	env = { HOME = os.getenv("HOME") or "" },
+
+	fn = {
+		expand = function(x)
+			if x == "~" then
+				return os.getenv("HOME") or ""
+			end
+			return x
+		end,
+		fnamemodify = function(path, _)
+			return path
+		end,
+		isdirectory = function(_)
+			return 1
+		end,
+		stdpath = function(_)
+			return "/tmp"
+		end,
+		writefile = function(_, _, _)
+			return 0
+		end,
+	},
+}


### PR DESCRIPTION
When looking at AtlasPulls for Github the author for some users was displaying: "vim.NIL", this seems to be caused by them not having a profile name set. This PR adds a fallback to display the github username in that case.

I haven't tested this for Bitbucket as I don't use that.