### PR TITLE
feat: add support for jira server API

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ issues = {
       email = "you@example.com",
       --- See: https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
       token = "your_jira_api_token",
+      auth_method = "basic", -- "basic" or "bearer", defaults to "basic". If using bearer, set `token` to your API token and `email` can be left empty.
+      api_version = "3", -- Jira REST API version, defaults to "3". Set to "2" if you're using Jira Server with older API.
       cache_ttl = 300,
 
       project_config = {

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ issues = {
       email = "you@example.com",
       --- See: https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
       token = "your_jira_api_token",
-      auth_method = "basic", -- "basic" or "bearer", defaults to "basic". If using bearer, set `token` to your API token and `email` can be left empty.
+      auth_method = "basic", -- "basic" or "bearer", defaults to "basic". If using bearer, set `token` to your API token.
       api_type = "cloud", -- either "cloud" or "server", defaults to "cloud". Cloud API is v3, server API is v2
       cache_ttl = 300,
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ issues = {
       --- See: https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
       token = "your_jira_api_token",
       auth_method = "basic", -- "basic" or "bearer", defaults to "basic". If using bearer, set `token` to your API token and `email` can be left empty.
-      api_version = "3", -- Jira REST API version, defaults to "3". Set to "2" if you're using Jira Server with older API.
+      api_type = "cloud", -- either "cloud" or "server", defaults to "cloud". Cloud API is v3, server API is v2
       cache_ttl = 300,
 
       project_config = {
@@ -223,6 +223,7 @@ issues = {
   },
 },
 ```
+
 <img alt="Edit/Create Issue" src="https://github.com/user-attachments/assets/76913fbf-1667-4f35-9962-d3c1b4619c7f">
 
 </details>

--- a/lua/atlas/issues/providers/jira/actions/registry.lua
+++ b/lua/atlas/issues/providers/jira/actions/registry.lua
@@ -504,26 +504,66 @@ local ACTIONS = {
 							or { id = fields.assignee.account_id }
 					end
 
-					issues_api.create_issue(api_fields, function(result, err)
-						if err then
-							submit_done(false, err)
-							done(nil, err)
-							return
-						end
+					local raw_desc = desc
+					local function commit_create(payload, was_retry)
+						issues_api.create_issue(payload, function(result, err)
+							if err then
+								if
+									not was_retry
+									and type(raw_desc) == "string"
+									and err:find("Field 'description' cannot be set", 1, true)
+								then
+									local retry = vim.deepcopy(payload)
+									retry.description = nil
+									commit_create(retry, true)
+									return
+								end
+								submit_done(false, err)
+								done(nil, err)
+								return
+							end
 
-						if result and result.key then
-							footer.notify("success", string.format("Created %s", result.key), 2000)
-							submit_done(true, nil)
-							done(
-								{ changed_issue_key = result.key, message = string.format("Created %s", result.key) },
-								nil
-							)
-							return
-						end
+							if result and result.key then
+								if was_retry and type(raw_desc) == "string" then
+									local update = { description = raw_desc }
+									issues_api.update_issue(result.key, update, function(ok)
+										if ok then
+											footer.notify("success", string.format("Created %s", result.key), 2000)
+											submit_done(true, nil)
+											done(
+												{ changed_issue_key = result.key, message = "Created " .. result.key },
+												nil
+											)
+										else
+											footer.notify("warn", "Issue created but failed to set description", 3000)
+											submit_done(true, "Description not set")
+											done(
+												{ changed_issue_key = result.key, message = "Created " .. result.key },
+												nil
+											)
+										end
+									end)
+									return
+								end
 
-						submit_done(false, "Invalid response")
-						done(nil, "Invalid response")
-					end)
+								footer.notify("success", string.format("Created %s", result.key), 2000)
+								submit_done(true, nil)
+								done(
+									{
+										changed_issue_key = result.key,
+										message = string.format("Created %s", result.key),
+									},
+									nil
+								)
+								return
+							end
+
+							submit_done(false, "Invalid response")
+							done(nil, "Invalid response")
+						end)
+					end
+
+					commit_create(api_fields, false)
 				end, {
 					summary = "",
 					description = nil,

--- a/lua/atlas/issues/providers/jira/actions/registry.lua
+++ b/lua/atlas/issues/providers/jira/actions/registry.lua
@@ -386,10 +386,15 @@ local ACTIONS = {
 
 			local function open_editor(initial_description)
 				issue_editor.open(function(fields, submit_done)
+					local api_version = tostring(config.jira_config().api_version or "3")
+					local is_v2 = api_version:match("^2")
+
 					local desc = fields.description
 					local payload = {
 						summary = fields.summary,
-						description = type(desc) == "string" and md_to_adf.to_adf(desc) or vim.NIL,
+						description = type(desc) == "string"
+							and (is_v2 and desc or md_to_adf.to_adf(desc))
+							or vim.NIL,
 					}
 
 					if fields.issue_type and fields.issue_type.id and fields.issue_type.id ~= "" then
@@ -397,7 +402,9 @@ local ACTIONS = {
 					end
 
 					if fields.assignee and fields.assignee.account_id then
-						payload.assignee = { id = fields.assignee.account_id }
+						payload.assignee = is_v2
+							and { name = fields.assignee.account_id }
+							or { id = fields.assignee.account_id }
 					else
 						payload.assignee = vim.NIL
 					end
@@ -447,6 +454,10 @@ local ACTIONS = {
 				if type(description) == "table" then
 					open_editor(adf.to_markdown(description))
 					return
+        elseif type(description) == "string" then
+          -- Description is a sting in Jira server API
+          open_editor(description)
+          return
 				end
 				open_editor("")
 			end)
@@ -484,13 +495,18 @@ local ACTIONS = {
 						return
 					end
 
+					local api_version = tostring(config.jira_config().api_version or "3")
+					local is_v2 = api_version:match("^2")
+
 					local desc = fields.description
 					if type(desc) == "string" then
-						api_fields.description = md_to_adf.to_adf(desc)
+						api_fields.description = is_v2 and desc or md_to_adf.to_adf(desc)
 					end
 
 					if fields.assignee and fields.assignee.account_id then
-						api_fields.assignee = { id = fields.assignee.account_id }
+						api_fields.assignee = is_v2
+							and { name = fields.assignee.account_id }
+							or { id = fields.assignee.account_id }
 					end
 
 					issues_api.create_issue(api_fields, function(result, err)

--- a/lua/atlas/issues/providers/jira/actions/registry.lua
+++ b/lua/atlas/issues/providers/jira/actions/registry.lua
@@ -386,13 +386,13 @@ local ACTIONS = {
 
 			local function open_editor(initial_description)
 				issue_editor.open(function(fields, submit_done)
-					local api_version = tostring(config.jira_config().api_version or "3")
-					local is_v2 = api_version:match("^2")
+					local is_server = config.jira_config().api_type == "server"
 
 					local desc = fields.description
 					local payload = {
 						summary = fields.summary,
-						description = type(desc) == "string" and (is_v2 and desc or md_to_adf.to_adf(desc)) or vim.NIL,
+						description = type(desc) == "string" and (is_server and desc or md_to_adf.to_adf(desc))
+							or vim.NIL,
 					}
 
 					if fields.issue_type and fields.issue_type.id and fields.issue_type.id ~= "" then
@@ -400,7 +400,7 @@ local ACTIONS = {
 					end
 
 					if fields.assignee and fields.assignee.account_id then
-						payload.assignee = is_v2 and { name = fields.assignee.account_id }
+						payload.assignee = is_server and { name = fields.assignee.account_id }
 							or { id = fields.assignee.account_id }
 					else
 						payload.assignee = vim.NIL
@@ -492,16 +492,15 @@ local ACTIONS = {
 						return
 					end
 
-					local api_version = tostring(config.jira_config().api_version or "3")
-					local is_v2 = api_version:match("^2")
+					local is_server = config.jira_config().api_type == "server"
 
 					local desc = fields.description
 					if type(desc) == "string" then
-						api_fields.description = is_v2 and desc or md_to_adf.to_adf(desc)
+						api_fields.description = is_server and desc or md_to_adf.to_adf(desc)
 					end
 
 					if fields.assignee and fields.assignee.account_id then
-						api_fields.assignee = is_v2 and { name = fields.assignee.account_id }
+						api_fields.assignee = is_server and { name = fields.assignee.account_id }
 							or { id = fields.assignee.account_id }
 					end
 
@@ -1044,7 +1043,7 @@ local ACTIONS = {
 
 			local function unsubscribe(account_id)
 				local param_name = "accountId"
-				if config.jira_config().api_version:match("^2") then
+				if config.jira_config().api_type == "server" then
 					param_name = "username"
 				end
 

--- a/lua/atlas/issues/providers/jira/actions/registry.lua
+++ b/lua/atlas/issues/providers/jira/actions/registry.lua
@@ -392,9 +392,7 @@ local ACTIONS = {
 					local desc = fields.description
 					local payload = {
 						summary = fields.summary,
-						description = type(desc) == "string"
-							and (is_v2 and desc or md_to_adf.to_adf(desc))
-							or vim.NIL,
+						description = type(desc) == "string" and (is_v2 and desc or md_to_adf.to_adf(desc)) or vim.NIL,
 					}
 
 					if fields.issue_type and fields.issue_type.id and fields.issue_type.id ~= "" then
@@ -402,8 +400,7 @@ local ACTIONS = {
 					end
 
 					if fields.assignee and fields.assignee.account_id then
-						payload.assignee = is_v2
-							and { name = fields.assignee.account_id }
+						payload.assignee = is_v2 and { name = fields.assignee.account_id }
 							or { id = fields.assignee.account_id }
 					else
 						payload.assignee = vim.NIL
@@ -454,10 +451,10 @@ local ACTIONS = {
 				if type(description) == "table" then
 					open_editor(adf.to_markdown(description))
 					return
-        elseif type(description) == "string" then
-          -- Description is a sting in Jira server API
-          open_editor(description)
-          return
+				elseif type(description) == "string" then
+					-- Description is a sting in Jira server API
+					open_editor(description)
+					return
 				end
 				open_editor("")
 			end)
@@ -504,8 +501,7 @@ local ACTIONS = {
 					end
 
 					if fields.assignee and fields.assignee.account_id then
-						api_fields.assignee = is_v2
-							and { name = fields.assignee.account_id }
+						api_fields.assignee = is_v2 and { name = fields.assignee.account_id }
 							or { id = fields.assignee.account_id }
 					end
 
@@ -1047,9 +1043,14 @@ local ACTIONS = {
 			end
 
 			local function unsubscribe(account_id)
+				local param_name = "accountId"
+				if config.jira_config().api_version:match("^2") then
+					param_name = "username"
+				end
+
 				svc.request(
 					"DELETE",
-					string.format("/issue/%s/watchers?accountId=%s", issue_key, account_id),
+					string.format("/issue/%s/watchers?%s=%s", issue_key, param_name, account_id),
 					nil,
 					function(_, err)
 						finish(err == nil and false or nil, err)

--- a/lua/atlas/issues/providers/jira/actions/registry.lua
+++ b/lua/atlas/issues/providers/jira/actions/registry.lua
@@ -7,7 +7,7 @@ local issues_api = require("atlas.issues.providers.jira.api.issues")
 local transitions_api = require("atlas.issues.providers.jira.api.transitions")
 local users_api = require("atlas.issues.providers.jira.api.users")
 local issues_state = require("atlas.issues.state")
-local service = require("atlas.issues.providers.jira.api.service")
+local config = require("atlas.issues.providers.jira.api.config")
 
 ---@param ctx table
 ---@return boolean
@@ -934,7 +934,7 @@ local ACTIONS = {
 				return
 			end
 
-			local base_url = tostring(service.jira_config().base_url or ""):gsub("/$", "")
+			local base_url = tostring(config.jira_config().base_url or ""):gsub("/$", "")
 			local issue_key = tostring(issue.key or "")
 			if base_url == "" or issue_key == "" then
 				done(nil, "No URL found for issue")
@@ -980,7 +980,7 @@ local ACTIONS = {
 				return
 			end
 
-			local base_url = tostring(service.jira_config().base_url or ""):gsub("/$", "")
+			local base_url = tostring(config.jira_config().base_url or ""):gsub("/$", "")
 			local issue_key = tostring(issue.key or "")
 			local url = (base_url ~= "" and issue_key ~= "") and string.format("%s/browse/%s", base_url, issue_key)
 				or ""

--- a/lua/atlas/issues/providers/jira/api/comments.lua
+++ b/lua/atlas/issues/providers/jira/api/comments.lua
@@ -3,6 +3,7 @@ local M = {}
 local service = require("atlas.issues.providers.jira.api.service")
 local normalizer = require("atlas.issues.providers.jira.api.mapper")
 local markdown = require("atlas.issues.providers.jira.converted.markdown")
+local config = require("atlas.issues.providers.jira.api.config")
 
 local PANEL_CACHE_TTL = 300
 
@@ -67,7 +68,12 @@ function M.add_comment(issue_key, comment, opts, callback)
 	end
 
 	local endpoint = string.format("/issue/%s/comment", issue_key)
-	local payload = { body = markdown.to_adf(body) }
+	local payload = { body = "" }
+	if config.jira_config().api_version:match("^3") then
+		payload.body = markdown.to_adf(body)
+	else
+		payload.body = body
+	end
 
 	local parent_id = opts and opts.parent_id or nil
 	if parent_id ~= nil then
@@ -115,8 +121,14 @@ function M.edit_comment(issue_key, comment_id, comment, callback)
 	end
 
 	local endpoint = string.format("/issue/%s/comment/%s", issue_key, id)
+	local payload = { body = "" }
+	if config.jira_config().api_version:match("^3") then
+		payload.body = markdown.to_adf(body)
+	else
+		payload.body = body
+	end
 
-	return service.request("PUT", endpoint, { body = markdown.to_adf(body) }, function(result, err)
+	return service.request("PUT", endpoint, payload, function(result, err)
 		if err or not result then
 			callback(nil, err or "Empty response")
 			return

--- a/lua/atlas/issues/providers/jira/api/comments.lua
+++ b/lua/atlas/issues/providers/jira/api/comments.lua
@@ -69,7 +69,7 @@ function M.add_comment(issue_key, comment, opts, callback)
 
 	local endpoint = string.format("/issue/%s/comment", issue_key)
 	local payload = { body = "" }
-	if config.jira_config().api_version:match("^3") then
+	if config.jira_config().api_type == "cloud" then
 		payload.body = markdown.to_adf(body)
 	else
 		payload.body = body
@@ -122,7 +122,7 @@ function M.edit_comment(issue_key, comment_id, comment, callback)
 
 	local endpoint = string.format("/issue/%s/comment/%s", issue_key, id)
 	local payload = { body = "" }
-	if config.jira_config().api_version:match("^3") then
+	if config.jira_config().api_type == "cloud" then
 		payload.body = markdown.to_adf(body)
 	else
 		payload.body = body

--- a/lua/atlas/issues/providers/jira/api/config.lua
+++ b/lua/atlas/issues/providers/jira/api/config.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+local config = require("atlas.config")
+
+---@return AtlasJiraIssuesConfig
+function M.jira_config()
+	local opts = config.options
+	local issues = opts and opts.issues or nil
+	return (issues and issues.providers and issues.providers.jira) or {}
+end
+
+return M

--- a/lua/atlas/issues/providers/jira/api/config.lua
+++ b/lua/atlas/issues/providers/jira/api/config.lua
@@ -8,7 +8,8 @@ function M.jira_config()
 	local issues = opts and opts.issues or nil
 	local jira_config = (issues and issues.providers and issues.providers.jira) or {}
 
-	jira_config.api_version = tostring(jira_config.api_version or "3")
+	jira_config.auth_method = jira_config.auth_method or "basic"
+	jira_config.api_type = jira_config.api_type or "cloud"
 
 	return jira_config
 end

--- a/lua/atlas/issues/providers/jira/api/config.lua
+++ b/lua/atlas/issues/providers/jira/api/config.lua
@@ -6,7 +6,11 @@ local config = require("atlas.config")
 function M.jira_config()
 	local opts = config.options
 	local issues = opts and opts.issues or nil
-	return (issues and issues.providers and issues.providers.jira) or {}
+	local jira_config = (issues and issues.providers and issues.providers.jira) or {}
+
+	jira_config.api_version = tostring(jira_config.api_version or "3")
+
+	return jira_config
 end
 
 return M

--- a/lua/atlas/issues/providers/jira/api/issues.lua
+++ b/lua/atlas/issues/providers/jira/api/issues.lua
@@ -42,9 +42,7 @@ end
 ---@param ctx table|nil
 ---@return { job_id: integer, cancel: fun() }|nil
 local function search_jql_request(data, on_done, ctx)
-	local is_v2 = config.jira_config().api_version:match("^2")
-
-	if is_v2 then
+	if config.jira_config().api_type == "server" then
 		local payload = vim.deepcopy(data)
 		payload.startAt = tonumber(payload.nextPageToken) or 0
 		payload.nextPageToken = nil
@@ -229,10 +227,10 @@ function M.get_issue_history_page(issue_key, start_at, max_results, on_done, opt
 		end
 	end
 
-	local is_v2 = config.jira_config().api_version:match("^2")
+	local is_server = config.jira_config().api_type == "server"
 
 	local endpoint
-	if is_v2 then
+	if is_server then
 		endpoint = string.format("/issue/%s?expand=changelog", issue_key)
 	else
 		endpoint = string.format("/issue/%s/changelog?startAt=%d&maxResults=%d", issue_key, start, size)
@@ -245,7 +243,7 @@ function M.get_issue_history_page(issue_key, start_at, max_results, on_done, opt
 		end
 
 		local raw = result
-		if is_v2 then
+		if is_server then
 			raw = type(result.changelog) == "table" and result.changelog or { values = {} }
 			if raw.values == nil and raw.histories ~= nil then
 				raw.values = raw.histories

--- a/lua/atlas/issues/providers/jira/api/issues.lua
+++ b/lua/atlas/issues/providers/jira/api/issues.lua
@@ -537,6 +537,30 @@ function M.get_create_meta(project_key, callback)
 	end
 
 	local escaped_key = vim.fn.escape(project_key, "&=?")
+
+	if config.jira_config().api_type == "server" then
+		local endpoint = string.format("/issue/createmeta/%s/issuetypes", escaped_key)
+		return service.request("GET", endpoint, nil, function(result, err)
+			if err ~= nil or type(result) ~= "table" then
+				callback(nil, err or "Empty response")
+				return
+			end
+
+			local raw_types = type(result.values) == "table" and result.values or {}
+			local issue_types = {}
+			for _, raw in ipairs(raw_types) do
+				local issue_type = normalizer.to_issue_type(raw)
+				if issue_type ~= nil then
+					table.insert(issue_types, issue_type)
+				end
+			end
+			callback(issue_types, nil)
+		end, {
+			action = "Fetch create metadata",
+			project_key = project_key,
+		})
+	end
+
 	local endpoint = string.format("/issue/createmeta?projectKeys=%s&expand=projects.issuetypes", escaped_key)
 
 	return service.request("GET", endpoint, nil, function(result, err)

--- a/lua/atlas/issues/providers/jira/api/issues.lua
+++ b/lua/atlas/issues/providers/jira/api/issues.lua
@@ -8,7 +8,7 @@ local logger = require("atlas.core.logger")
 local CACHE_TTL = 300
 
 local function story_points_field()
-	local cfg = service.jira_config()
+	local cfg = require("atlas.issues.providers.jira.api.config").jira_config()
 	local project_config = cfg.project_config or {}
 	return tostring(project_config.story_points_field or "customfield_10016")
 end

--- a/lua/atlas/issues/providers/jira/api/issues.lua
+++ b/lua/atlas/issues/providers/jira/api/issues.lua
@@ -37,6 +37,44 @@ local function url_encode(str)
 	end))
 end
 
+-- Tries /search/jql first; on HTTP 404 falls back to /search (older Jira API versions)
+---@param data table
+---@param on_done fun(result: table|nil, err: string|nil)
+---@param ctx table|nil
+---@return { job_id: integer, cancel: fun() }|nil
+local function search_jql_request(data, on_done, ctx)
+	local retried = false
+	local function attempt(endpoint)
+		local payload = data
+		if endpoint == "/search" then
+			payload = vim.deepcopy(data)
+			payload.startAt = tonumber(payload.nextPageToken) or 0
+			payload.nextPageToken = nil
+		end
+
+		return service.request("POST", endpoint, payload, function(result, err)
+			if not retried and err and err:find("HTTP 404", 1, true) == 1 then
+				retried = true
+				logger.loginfo("Jira /search/jql returned 404, retrying with /search")
+				return attempt("/search")
+			end
+
+			if result and endpoint == "/search" then
+        -- Old /search endpoint use offset-based pagination instead of token-based
+				local start_at = tonumber(result.startAt) or 0
+				local max_results = tonumber(result.maxResults) or #(result.issues or {})
+				local total = tonumber(result.total) or 0
+				local next_start = start_at + max_results
+				result.isLast = next_start >= total
+				result.nextPageToken = result.isLast and nil or tostring(next_start)
+			end
+
+			on_done(result, err)
+		end, ctx)
+	end
+	return attempt("/search/jql")
+end
+
 ---@class JiraIssueSearchPage
 ---@field issues Issue[]
 ---@field nextPageToken string|nil
@@ -69,7 +107,7 @@ function M.search_issues(jql, on_done, opts)
 		maxResults = page_size,
 	}
 
-	return service.request("POST", "/search/jql", data, function(result, err)
+	return search_jql_request(data, function(result, err)
 		if err or not result then
 			on_done(nil, err or "Empty response")
 			return
@@ -261,7 +299,7 @@ function M.get_issue_detail(issue_key, on_done, opts)
 		maxResults = 1,
 	}
 
-	return service.request("POST", "/search/jql", data, function(result, err)
+	return search_jql_request(data, function(result, err)
 		if err or not result then
 			logger.logerror("Jira detail fetch failed", {
 				issue_key = issue_key,
@@ -331,11 +369,13 @@ function M.get_custom_fields(issue_key, fields, on_done, opts)
 		end
 	end
 
-	return service.request("POST", "/search/jql", {
+	local data = {
 		jql = "key = " .. issue_key,
 		fields = fields,
 		maxResults = 1,
-	}, function(result, err)
+	}
+
+	return search_jql_request(data, function(result, err)
 		if err or not result then
 			on_done(nil, err or "Empty response")
 			return

--- a/lua/atlas/issues/providers/jira/api/issues.lua
+++ b/lua/atlas/issues/providers/jira/api/issues.lua
@@ -4,12 +4,12 @@ local service = require("atlas.issues.providers.jira.api.service")
 local normalizer = require("atlas.issues.providers.jira.api.mapper")
 local cache = require("atlas.core.cache")
 local logger = require("atlas.core.logger")
+local config = require("atlas.issues.providers.jira.api.config")
 
 local CACHE_TTL = 300
 
 local function story_points_field()
-	local cfg = require("atlas.issues.providers.jira.api.config").jira_config()
-	local project_config = cfg.project_config or {}
+	local project_config = config.jira_config().project_config or {}
 	return tostring(project_config.story_points_field or "customfield_10016")
 end
 
@@ -37,30 +37,20 @@ local function url_encode(str)
 	end))
 end
 
--- Tries /search/jql first; on HTTP 404 falls back to /search (older Jira API versions)
 ---@param data table
 ---@param on_done fun(result: table|nil, err: string|nil)
 ---@param ctx table|nil
 ---@return { job_id: integer, cancel: fun() }|nil
 local function search_jql_request(data, on_done, ctx)
-	local retried = false
-	local function attempt(endpoint)
-		local payload = data
-		if endpoint == "/search" then
-			payload = vim.deepcopy(data)
-			payload.startAt = tonumber(payload.nextPageToken) or 0
-			payload.nextPageToken = nil
-		end
+	local is_v2 = config.jira_config().api_version:match("^2")
 
-		return service.request("POST", endpoint, payload, function(result, err)
-			if not retried and err and err:find("HTTP 404", 1, true) == 1 then
-				retried = true
-				logger.loginfo("Jira /search/jql returned 404, retrying with /search")
-				return attempt("/search")
-			end
+	if is_v2 then
+		local payload = vim.deepcopy(data)
+		payload.startAt = tonumber(payload.nextPageToken) or 0
+		payload.nextPageToken = nil
 
-			if result and endpoint == "/search" then
-        -- Old /search endpoint use offset-based pagination instead of token-based
+		return service.request("POST", "/search", payload, function(result, err)
+			if result then
 				local start_at = tonumber(result.startAt) or 0
 				local max_results = tonumber(result.maxResults) or #(result.issues or {})
 				local total = tonumber(result.total) or 0
@@ -68,11 +58,13 @@ local function search_jql_request(data, on_done, ctx)
 				result.isLast = next_start >= total
 				result.nextPageToken = result.isLast and nil or tostring(next_start)
 			end
-
+			on_done(result, err)
+		end, ctx)
+	else
+		return service.request("POST", "/search/jql", data, function(result, err)
 			on_done(result, err)
 		end, ctx)
 	end
-	return attempt("/search/jql")
 end
 
 ---@class JiraIssueSearchPage
@@ -237,7 +229,14 @@ function M.get_issue_history_page(issue_key, start_at, max_results, on_done, opt
 		end
 	end
 
-	local endpoint = string.format("/issue/%s/changelog?startAt=%d&maxResults=%d", issue_key, start, size)
+	local is_v2 = config.jira_config().api_version:match("^2")
+
+	local endpoint
+	if is_v2 then
+		endpoint = string.format("/issue/%s?expand=changelog", issue_key)
+	else
+		endpoint = string.format("/issue/%s/changelog?startAt=%d&maxResults=%d", issue_key, start, size)
+	end
 
 	return service.request("GET", endpoint, nil, function(result, err)
 		if err or not result then
@@ -245,7 +244,15 @@ function M.get_issue_history_page(issue_key, start_at, max_results, on_done, opt
 			return
 		end
 
-		local page = normalizer.to_history_page(result, start, size)
+		local raw = result
+		if is_v2 then
+			raw = type(result.changelog) == "table" and result.changelog or { values = {} }
+			if raw.values == nil and raw.histories ~= nil then
+				raw.values = raw.histories
+			end
+		end
+
+		local page = normalizer.to_history_page(raw, start, size)
 		service.set_memory_cache(cache_key, page, CACHE_TTL)
 		on_done(page, nil)
 	end, {

--- a/lua/atlas/issues/providers/jira/api/mapper.lua
+++ b/lua/atlas/issues/providers/jira/api/mapper.lua
@@ -259,8 +259,8 @@ end
 ---@param issue_key string|nil
 ---@return IssueComment[]
 function M.to_comments_list(raw, issue_key)
-	local service = require("atlas.issues.providers.jira.api.service")
-	local base_url = tostring(service.jira_config().base_url or ""):gsub("/$", "")
+	local config = require("atlas.issues.providers.jira.api.config")
+	local base_url = tostring(config.jira_config().base_url or ""):gsub("/$", "")
 	local comments = {}
 	for _, raw_comment in ipairs((type(raw) == "table" and raw.comments) or {}) do
 		local comment = normalize_comment(raw_comment, issue_key, base_url)

--- a/lua/atlas/issues/providers/jira/api/mapper.lua
+++ b/lua/atlas/issues/providers/jira/api/mapper.lua
@@ -249,8 +249,13 @@ local function normalize_comment(raw_comment, issue_key, base_url)
 		self = raw_comment.self and tostring(raw_comment.self) or nil,
 		url = url,
 		author = normalize_issue_user(raw_comment.author),
-		body = adf.to_markdown(type(raw_comment.body) == "table" and raw_comment.body or nil),
-		_body = type(raw_comment.body) == "table" and raw_comment.body or nil,
+		-- Jira cloud returns body as ADF, while Jira server returns it as string
+		body = type(raw_comment.body) == "table" and adf.to_markdown(raw_comment.body)
+			or type(raw_comment.body) == "string" and raw_comment.body
+			or nil,
+		_body = type(raw_comment.body) == "table" and raw_comment.body
+			or type(raw_comment.body) == "string" and raw_comment.body
+			or nil,
 		created = raw_comment.created and tostring(raw_comment.created) or nil,
 		updated = raw_comment.updated and tostring(raw_comment.updated) or nil,
 		parent_id = parent_id,

--- a/lua/atlas/issues/providers/jira/api/mapper.lua
+++ b/lua/atlas/issues/providers/jira/api/mapper.lua
@@ -122,7 +122,10 @@ local function normalize_issue_user(raw_user)
 		return nil
 	end
 
-	local account_id = raw_user.accountId and tostring(raw_user.accountId) or ""
+	-- Replace accountId with name to support Jira server instances
+	local account_id = raw_user.accountId and tostring(raw_user.accountId)
+		or raw_user.name and tostring(raw_user.name)
+		or ""
 	local display_name = raw_user.displayName and tostring(raw_user.displayName) or ""
 	if account_id == "" or display_name == "" then
 		return nil

--- a/lua/atlas/issues/providers/jira/api/projects.lua
+++ b/lua/atlas/issues/providers/jira/api/projects.lua
@@ -59,11 +59,10 @@ function M.get_projects(opts, callback)
 		if cancelled then
 			return
 		end
-		local jira_config = config.jira_config()
-		local is_v2 = jira_config.api_version:match("^2")
-		local path = is_v2 and "/project" or "/project/search"
+		local is_server = config.jira_config().api_type == "server"
+		local path = is_server and "/project" or "/project/search"
 		local endpoint
-		if is_v2 then
+		if is_server then
 			endpoint = path
 		else
 			endpoint = string.format(

--- a/lua/atlas/issues/providers/jira/api/projects.lua
+++ b/lua/atlas/issues/providers/jira/api/projects.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local service = require("atlas.issues.providers.jira.api.service")
 local normalizer = require("atlas.issues.providers.jira.api.mapper")
+local config = require("atlas.issues.providers.jira.api.config")
 
 ---@class JiraProjectGroup
 ---@field category table|nil
@@ -58,9 +59,14 @@ function M.get_projects(opts, callback)
 		if cancelled then
 			return
 		end
-
+    local jira_config = config.jira_config()
+    local path = "/project/search"
+    if jira_config.api_version and jira_config.api_version:match("^2") then
+      path = "/project"
+    end
 		local endpoint = string.format(
-			"/project/search?maxResults=%d&startAt=%d&status=%s",
+			"%s?maxResults=%d&startAt=%d&status=%s",
+      path,
 			max_results,
 			start_at,
 			vim.fn.escape(status, "&=?")

--- a/lua/atlas/issues/providers/jira/api/projects.lua
+++ b/lua/atlas/issues/providers/jira/api/projects.lua
@@ -59,20 +59,24 @@ function M.get_projects(opts, callback)
 		if cancelled then
 			return
 		end
-    local jira_config = config.jira_config()
-    local path = "/project/search"
-    if jira_config.api_version and jira_config.api_version:match("^2") then
-      path = "/project"
-    end
-		local endpoint = string.format(
-			"%s?maxResults=%d&startAt=%d&status=%s",
-      path,
-			max_results,
-			start_at,
-			vim.fn.escape(status, "&=?")
-		)
-		if query ~= "" then
-			endpoint = endpoint .. "&query=" .. vim.fn.escape(query, "&=?")
+		local jira_config = config.jira_config()
+		local api_version = tostring(jira_config.api_version or "")
+		local is_v2 = api_version:match("^2")
+		local path = is_v2 and "/project" or "/project/search"
+		local endpoint
+		if is_v2 then
+			endpoint = path
+		else
+			endpoint = string.format(
+				"%s?maxResults=%d&startAt=%d&status=%s",
+				path,
+				max_results,
+				start_at,
+				vim.fn.escape(status, "&=?")
+			)
+			if query ~= "" then
+				endpoint = endpoint .. "&query=" .. vim.fn.escape(query, "&=?")
+			end
 		end
 
 		active_handle = service.request("GET", endpoint, nil, function(result, err)
@@ -85,7 +89,19 @@ function M.get_projects(opts, callback)
 				return
 			end
 
-			for _, raw in ipairs(result.values or {}) do
+			-- Handle differences in response structure between API versions
+			local normalized = result
+			if path == "/project" then
+				local items = type(result) == "table" and result or {}
+				normalized = {
+					values = items,
+					isLast = true,
+					startAt = 0,
+					maxResults = #items,
+				}
+			end
+
+			for _, raw in ipairs(normalized.values or {}) do
 				local project = normalizer.to_project(raw)
 				if project then
 					table.insert(projects, project)
@@ -93,12 +109,12 @@ function M.get_projects(opts, callback)
 			end
 
 			pages_loaded = pages_loaded + 1
-			if result.isLast == true or pages_loaded >= total_pages then
+			if normalized.isLast == true or pages_loaded >= total_pages then
 				callback(build_groups(projects), nil)
 				return
 			end
 
-			local next_start = tonumber(result.startAt) or start_at
+			local next_start = tonumber(normalized.startAt) or start_at
 			fetch_page(next_start + max_results)
 		end, {
 			action = "Fetch projects",

--- a/lua/atlas/issues/providers/jira/api/projects.lua
+++ b/lua/atlas/issues/providers/jira/api/projects.lua
@@ -60,8 +60,7 @@ function M.get_projects(opts, callback)
 			return
 		end
 		local jira_config = config.jira_config()
-		local api_version = tostring(jira_config.api_version or "")
-		local is_v2 = api_version:match("^2")
+		local is_v2 = jira_config.api_version:match("^2")
 		local path = is_v2 and "/project" or "/project/search"
 		local endpoint
 		if is_v2 then

--- a/lua/atlas/issues/providers/jira/api/service.lua
+++ b/lua/atlas/issues/providers/jira/api/service.lua
@@ -13,7 +13,9 @@ function M.get_auth()
 	local token = jira.token
 
 	if not base_url or base_url == "" or not email or email == "" or not token or token == "" then
-		return "", "", "Missing Jira credentials in config (issues.providers.jira.base_url, issues.providers.jira.email, issues.providers.jira.token)"
+		return "",
+			"",
+			"Missing Jira credentials in config (issues.providers.jira.base_url, issues.providers.jira.email, issues.providers.jira.token)"
 	end
 
 	return base_url, email, nil
@@ -24,12 +26,12 @@ function M.build_headers()
 	local jira = config.jira_config()
 	local email = jira.email or ""
 	local token = jira.token or ""
-  local auth_header = "Basic " .. vim.base64.encode(string.format("%s:%s", email, token))
-  if jira.auth_method == "bearer" then
-    auth_header = "Bearer " .. token
-  end
+	local auth_header = "Basic " .. vim.base64.encode(string.format("%s:%s", email, token))
+	if jira.auth_method == "bearer" then
+		auth_header = "Bearer " .. token
+	end
 	return {
-    authorization = auth_header,
+		authorization = auth_header,
 		["Content-Type"] = "application/json",
 		Accept = "application/json",
 	}
@@ -42,7 +44,10 @@ end
 
 ---@return string
 function M.api_path()
-	local version = config.jira_config().api_version or "3"
+	local version = "3"
+	if config.jira_config().api_type == "server" then
+		version = "2"
+	end
 	return "/rest/api/" .. version
 end
 

--- a/lua/atlas/issues/providers/jira/api/service.lua
+++ b/lua/atlas/issues/providers/jira/api/service.lua
@@ -1,22 +1,13 @@
 local M = {}
 
-local config = require("atlas.config")
+local config = require("atlas.issues.providers.jira.api.config")
 local http = require("atlas.core.http")
 local memory_cache = require("atlas.core.memory_cache")
 local logger = require("atlas.core.logger")
 
-local API_PATH = "/rest/api/3"
-
----@return AtlasJiraIssuesConfig
-function M.jira_config()
-	local opts = config.options
-	local issues = opts and opts.issues or nil
-	return (issues and issues.providers and issues.providers.jira) or {}
-end
-
 ---@return string, string, string|nil
 function M.get_auth()
-	local jira = M.jira_config()
+	local jira = config.jira_config()
 	local base_url = jira.base_url
 	local email = jira.email
 	local token = jira.token
@@ -30,12 +21,15 @@ end
 
 ---@return table<string, string>
 function M.build_headers()
-	local jira = M.jira_config()
+	local jira = config.jira_config()
 	local email = jira.email or ""
 	local token = jira.token or ""
-	local auth = vim.base64.encode(string.format("%s:%s", email, token))
+  local auth_header = "Basic " .. vim.base64.encode(string.format("%s:%s", email, token))
+  if jira.auth_method == "bearer" then
+    auth_header = "Bearer " .. token
+  end
 	return {
-		Authorization = "Basic " .. auth,
+    authorization = auth_header,
 		["Content-Type"] = "application/json",
 		Accept = "application/json",
 	}
@@ -43,18 +37,24 @@ end
 
 ---@return string
 function M.base_url()
-	return tostring(M.jira_config().base_url or "")
+	return tostring(config.jira_config().base_url or "")
+end
+
+---@return string
+function M.api_path()
+	local version = config.jira_config().api_version or "3"
+	return "/rest/api/" .. version
 end
 
 ---@param endpoint string
 ---@return string
 function M.url(endpoint)
-	return M.base_url() .. API_PATH .. endpoint
+	return M.base_url() .. M.api_path() .. endpoint
 end
 
 ---@return number
 function M.cache_ttl()
-	return tonumber(M.jira_config().cache_ttl) or 300
+	return tonumber(config.jira_config().cache_ttl) or 300
 end
 
 function M.clear_memory_cache()

--- a/lua/atlas/issues/providers/jira/api/users.lua
+++ b/lua/atlas/issues/providers/jira/api/users.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local service = require("atlas.issues.providers.jira.api.service")
 local cache = require("atlas.core.cache")
+local config = require("atlas.issues.providers.jira.api.config")
 
 ---@param str string
 ---@return string
@@ -14,7 +15,7 @@ end
 ---@param callback fun(user: IssueUser|nil, err: string|nil)
 ---@return { job_id: integer, cancel: fun() }|nil
 function M.get_myself(callback)
-	local cache_key = "jira:myself:" .. (service.jira_config().email or "")
+	local cache_key = "jira:myself:" .. (config.jira_config().email or "")
 	local cached = cache.get(cache_key)
 	if cached and cached.value then
 		callback(cached.value, nil)

--- a/lua/atlas/issues/providers/jira/api/users.lua
+++ b/lua/atlas/issues/providers/jira/api/users.lua
@@ -54,8 +54,16 @@ function M.get_assignable_users(opts, query, callback)
 		return nil
 	end
 
+  local api_version = tostring(config.jira_config().api_version or "3")
+  local is_v2 = api_version:match("^2")
+
 	local q = tostring(query or "")
-	local params = { "query=" .. url_encode(q) }
+  local params = {}
+  if is_v2 then
+    table.insert(params, "username=" .. url_encode(q))
+  else
+    table.insert(params, "query=" .. url_encode(q))
+  end
 	if issue_key ~= "" then
 		table.insert(params, "issueKey=" .. url_encode(issue_key))
 	end
@@ -73,8 +81,12 @@ function M.get_assignable_users(opts, query, callback)
 		local users = {}
 		for _, raw in ipairs(result) do
 			if type(raw) == "table" then
+        local account_id = tostring(raw.accountId or "")
+        if is_v2 then
+          account_id = tostring(raw.name or "")
+        end
 				table.insert(users, {
-					account_id = tostring(raw.accountId or ""),
+					account_id = account_id,
 					display_name = tostring(raw.displayName or ""),
 				})
 			end

--- a/lua/atlas/issues/providers/jira/api/users.lua
+++ b/lua/atlas/issues/providers/jira/api/users.lua
@@ -32,7 +32,7 @@ function M.get_myself(callback)
 			display_name = tostring(result.displayName or ""),
 		}
 		-- Jira cloud uses `accountId` while Jira server uses `name`
-		if config.jira_config().api_version:match("^2") then
+		if config.jira_config().api_type == "server" then
 			user.account_id = tostring(result.name or "")
 		else
 			user.account_id = tostring(result.accountId or "")
@@ -59,12 +59,11 @@ function M.get_assignable_users(opts, query, callback)
 		return nil
 	end
 
-	local api_version = tostring(config.jira_config().api_version or "3")
-	local is_v2 = api_version:match("^2")
+	local is_server = config.jira_config().api_type == "server"
 
 	local q = tostring(query or "")
 	local params = {}
-	if is_v2 then
+	if is_server then
 		table.insert(params, "username=" .. url_encode(q))
 	else
 		table.insert(params, "query=" .. url_encode(q))
@@ -87,7 +86,7 @@ function M.get_assignable_users(opts, query, callback)
 		for _, raw in ipairs(result) do
 			if type(raw) == "table" then
 				local user = { display_name = tostring(raw.displayName or "") }
-				if is_v2 then
+				if is_server then
 					user.account_id = tostring(raw.name or "")
 				else
 					user.account_id = tostring(raw.accountId or "")
@@ -219,7 +218,7 @@ function M.assign_issue(issue_key, account_id, callback)
 
 	local endpoint = string.format("/issue/%s/assignee", issue_key)
 	local payload = {}
-	if config.jira_config().api_version:match("^2") then
+	if config.jira_config().api_type == "server" then
 		payload.name = normalized_account_id or vim.NIL
 	else
 		payload.accountId = normalized_account_id or vim.NIL
@@ -256,7 +255,7 @@ function M.change_reporter(issue_key, account_id, callback)
 
 	local endpoint = string.format("/issue/%s", issue_key)
 	local payload = { fields = { reporter = {} } }
-	if config.jira_config().api_version:match("^2") then
+	if config.jira_config().api_type == "server" then
 		payload.fields.reporter.name = account_id
 	else
 		payload.fields.reporter.accountId = account_id

--- a/lua/atlas/issues/providers/jira/api/users.lua
+++ b/lua/atlas/issues/providers/jira/api/users.lua
@@ -29,9 +29,14 @@ function M.get_myself(callback)
 		end
 
 		local user = {
-			account_id = tostring(result.accountId or ""),
 			display_name = tostring(result.displayName or ""),
 		}
+		-- Jira cloud uses `accountId` while Jira server uses `name`
+		if config.jira_config().api_version:match("^2") then
+			user.name = tostring(result.name or "")
+		else
+			user.account_id = tostring(result.accountId or "")
+		end
 
 		cache.set(cache_key, user, service.cache_ttl())
 		callback(user, nil)
@@ -54,16 +59,16 @@ function M.get_assignable_users(opts, query, callback)
 		return nil
 	end
 
-  local api_version = tostring(config.jira_config().api_version or "3")
-  local is_v2 = api_version:match("^2")
+	local api_version = tostring(config.jira_config().api_version or "3")
+	local is_v2 = api_version:match("^2")
 
 	local q = tostring(query or "")
-  local params = {}
-  if is_v2 then
-    table.insert(params, "username=" .. url_encode(q))
-  else
-    table.insert(params, "query=" .. url_encode(q))
-  end
+	local params = {}
+	if is_v2 then
+		table.insert(params, "username=" .. url_encode(q))
+	else
+		table.insert(params, "query=" .. url_encode(q))
+	end
 	if issue_key ~= "" then
 		table.insert(params, "issueKey=" .. url_encode(issue_key))
 	end
@@ -81,14 +86,13 @@ function M.get_assignable_users(opts, query, callback)
 		local users = {}
 		for _, raw in ipairs(result) do
 			if type(raw) == "table" then
-        local account_id = tostring(raw.accountId or "")
-        if is_v2 then
-          account_id = tostring(raw.name or "")
-        end
-				table.insert(users, {
-					account_id = account_id,
-					display_name = tostring(raw.displayName or ""),
-				})
+				local user = { display_name = tostring(raw.displayName or "") }
+				if is_v2 then
+					user.account_id = tostring(raw.name or "")
+				else
+					user.account_id = tostring(raw.accountId or "")
+				end
+				table.insert(users, user)
 			end
 		end
 
@@ -214,7 +218,12 @@ function M.assign_issue(issue_key, account_id, callback)
 	end
 
 	local endpoint = string.format("/issue/%s/assignee", issue_key)
-	local payload = { accountId = normalized_account_id or vim.NIL }
+	local payload = {}
+	if config.jira_config().api_version:match("^2") then
+		payload.name = normalized_account_id or vim.NIL
+	else
+		payload.accountId = normalized_account_id or vim.NIL
+	end
 
 	return service.request("PUT", endpoint, payload, function(_, err)
 		if err ~= nil then
@@ -246,13 +255,12 @@ function M.change_reporter(issue_key, account_id, callback)
 	end
 
 	local endpoint = string.format("/issue/%s", issue_key)
-	local payload = {
-		fields = {
-			reporter = {
-				accountId = account_id,
-			},
-		},
-	}
+	local payload = { fields = { reporter = {} } }
+	if config.jira_config().api_version:match("^2") then
+		payload.fields.reporter.name = account_id
+	else
+		payload.fields.reporter.accountId = account_id
+	end
 
 	return service.request("PUT", endpoint, payload, function(_, err)
 		if err ~= nil then

--- a/lua/atlas/issues/providers/jira/api/users.lua
+++ b/lua/atlas/issues/providers/jira/api/users.lua
@@ -33,7 +33,7 @@ function M.get_myself(callback)
 		}
 		-- Jira cloud uses `accountId` while Jira server uses `name`
 		if config.jira_config().api_version:match("^2") then
-			user.name = tostring(result.name or "")
+			user.account_id = tostring(result.name or "")
 		else
 			user.account_id = tostring(result.accountId or "")
 		end

--- a/lua/atlas/issues/providers/jira/api/users.lua
+++ b/lua/atlas/issues/providers/jira/api/users.lua
@@ -142,6 +142,21 @@ function M.get_permissions_bulk(opts, callback)
 
 	return service.request("POST", "/permissions/check", payload, function(result, err)
 		if err ~= nil or type(result) ~= "table" then
+			-- Handle 404 as a fallback since Jira server API don't have bulk permissions endpoint
+			if err and err:find("HTTP 404", 1, true) == 1 then
+				local fallback = {}
+				for _, key in ipairs(permissions_list) do
+					fallback[key] = {}
+					for _, pid in ipairs(project_ids) do
+						fallback[key][pid] = true
+					end
+					for _, iid in ipairs(issue_ids) do
+						fallback[key][iid] = true
+					end
+				end
+				callback(fallback, nil)
+				return
+			end
 			callback(nil, err or "Empty response")
 			return
 		end

--- a/lua/atlas/issues/providers/jira/config.lua
+++ b/lua/atlas/issues/providers/jira/config.lua
@@ -6,6 +6,8 @@
 --           base_url = "https://your-domain.atlassian.net",
 --           email    = vim.env.JIRA_EMAIL,
 --           token    = vim.env.JIRA_TOKEN,
+--           api_version = "3",
+--           auth_method = "basic", -- "basic" | "bearer"
 --           cache_ttl = 300,
 --           views = {
 --             { name = "Open",       key = "1", jql = "assignee = currentUser() AND resolution = Unresolved ORDER BY updated DESC" },
@@ -49,6 +51,8 @@
 ---@field base_url string
 ---@field email string
 ---@field token string
+---@field api_version string|nil
+---@field auth_method "basic"|"bearer"|nil
 ---@field cache_ttl number|nil
 ---@field views AtlasJiraViewConfig[]|nil
 ---@field project_config AtlasJiraProjectConfig|nil

--- a/lua/atlas/issues/providers/jira/config.lua
+++ b/lua/atlas/issues/providers/jira/config.lua
@@ -6,7 +6,7 @@
 --           base_url = "https://your-domain.atlassian.net",
 --           email    = vim.env.JIRA_EMAIL,
 --           token    = vim.env.JIRA_TOKEN,
---           api_version = "3",
+--           api_type = "cloud",
 --           auth_method = "basic", -- "basic" | "bearer"
 --           cache_ttl = 300,
 --           views = {
@@ -51,7 +51,7 @@
 ---@field base_url string
 ---@field email string
 ---@field token string
----@field api_version string|nil
+---@field api_type string|nil
 ---@field auth_method "basic"|"bearer"|nil
 ---@field cache_ttl number|nil
 ---@field views AtlasJiraViewConfig[]|nil

--- a/lua/atlas/issues/providers/jira/init.lua
+++ b/lua/atlas/issues/providers/jira/init.lua
@@ -331,7 +331,7 @@ end
 
 ---@return AtlasJiraViewConfig[]
 function M.views()
-	local cfg = require("atlas.issues.providers.jira.api.service").jira_config()
+	local cfg = require("atlas.issues.providers.jira.api.config").jira_config()
 	if cfg.views ~= nil then
 		return cfg.views
 	end

--- a/lua/atlas/issues/providers/jira/init.lua
+++ b/lua/atlas/issues/providers/jira/init.lua
@@ -301,7 +301,7 @@ function M.toggle_subscription(issue, on_done)
 	local function unsubscribe(account_id)
 		local jira_config = config.jira_config()
 		local user_param = "accountId=" .. account_id
-		if jira_config.api_version:match("^2") then
+		if jira_config.api_type == "server" then
 			user_param = "username=" .. account_id
 		end
 		return service.request(

--- a/lua/atlas/issues/providers/jira/init.lua
+++ b/lua/atlas/issues/providers/jira/init.lua
@@ -1,4 +1,5 @@
 local icons = require("atlas.ui.shared.icons")
+local config = require("atlas.issues.providers.jira.api.config")
 
 ---@class JiraProvider : IssuesProvider
 local M = {
@@ -298,9 +299,14 @@ function M.toggle_subscription(issue, on_done)
 	end
 
 	local function unsubscribe(account_id)
+		local jira_config = config.jira_config()
+		local user_param = "accountId=" .. account_id
+		if jira_config.api_version:match("^2") then
+			user_param = "username=" .. account_id
+		end
 		return service.request(
 			"DELETE",
-			string.format("/issue/%s/watchers?accountId=%s", issue_key, account_id),
+			string.format("/issue/%s/watchers?%s", issue_key, user_param),
 			nil,
 			function(_, err)
 				if err then

--- a/lua/atlas/issues/providers/jira/ui/panel.lua
+++ b/lua/atlas/issues/providers/jira/ui/panel.lua
@@ -51,7 +51,7 @@ function M.header_rows(issue)
 
 	local project_key = issue.project and issue.project.key or nil
 	if project_key then
-		local jira_cfg = require("atlas.issues.providers.jira.api.service").jira_config()
+		local jira_cfg = require("atlas.issues.providers.jira.api.config").jira_config()
 		local project_config = jira_cfg and jira_cfg.project_config and jira_cfg.project_config[project_key] or nil
 		if project_config then
 			if overview_state.custom_fields_loading then
@@ -154,7 +154,7 @@ function M.fetches(issue, refresh, opts)
 	local issue_key = tostring(issue.key or "")
 	local project_key = issue.project and issue.project.key or nil
 
-	local jira_cfg = require("atlas.issues.providers.jira.api.service").jira_config()
+	local jira_cfg = require("atlas.issues.providers.jira.api.config").jira_config()
 	local project_config = jira_cfg and jira_cfg.project_config and project_key and jira_cfg.project_config[project_key]
 		or nil
 


### PR DESCRIPTION
Hi there! Thank for this nice plugin. I extended it to support not only the cloud API of Jira, but also the server one. More precisely, this PR introduces two new options in the Jira provider:
- the `api_type`: can be `cloud` or `server`, defaults to `cloud` to keep the current behaviour.
- the `auth_method`: can be `basic` or `bearer`, defaults to `basic` to keep the current behaviour. `bearer` allows you to use an API token only instead of email/password.

For reference, I used [these docs](https://docs.atlassian.com/software/jira/docs/api/REST/7.6.1/) to implement the server API support. 

Of course, feel free to reject this PR if you think it clutters your plugin.
