### PR TITLE
feat(review): add keymap to delete a review comment at cursor

### DIFF
--- a/doc/atlas.txt
+++ b/doc/atlas.txt
@@ -725,6 +725,7 @@ Defaults live under `keymaps` in `setup()`. Each entry accepts:
           view_thread          = "K",
           add_pending_comment  = "c",
           add_comment          = "C",
+          delete_comment       = "dd",
           add_note             = "n",
           toggle_resolved      = "x",
         },

--- a/lua/atlas/config.lua
+++ b/lua/atlas/config.lua
@@ -168,6 +168,7 @@ M.options = {
 				view_thread = "K",
 				add_pending_comment = "c",
 				add_comment = "C",
+				delete_comment = "dd",
 				add_note = "n",
 				toggle_resolved = "x",
 			},

--- a/lua/atlas/core/keymaps.lua
+++ b/lua/atlas/core/keymaps.lua
@@ -46,6 +46,7 @@ local M = {}
 ---@field view_thread? AtlasKeymapValue
 ---@field add_pending_comment? AtlasKeymapValue
 ---@field add_comment? AtlasKeymapValue
+---@field delete_comment? AtlasKeymapValue
 ---@field add_note? AtlasKeymapValue
 ---@field toggle_resolved? AtlasKeymapValue
 
@@ -118,6 +119,7 @@ local M = {}
 ---| "pulls.review.view_thread"
 ---| "pulls.review.add_pending_comment"
 ---| "pulls.review.add_comment"
+---| "pulls.review.delete_comment"
 ---| "pulls.review.add_note"
 ---| "pulls.review.toggle_resolved"
 ---| "pulls.filter_status_open"
@@ -331,6 +333,7 @@ function M.validate()
 			"pulls.review.view_thread",
 			"pulls.review.add_pending_comment",
 			"pulls.review.add_comment",
+			"pulls.review.delete_comment",
 			"pulls.review.add_note",
 			"pulls.review.toggle_resolved",
 			"pulls.filter_status_open",

--- a/lua/atlas/pulls/diff/atlas/keymaps.lua
+++ b/lua/atlas/pulls/diff/atlas/keymaps.lua
@@ -431,9 +431,20 @@ function M.register_review(session, actions)
 			)
 			add(
 				review_actions,
+				item("pulls.review.delete_comment", {
+					desc = "Delete comment at cursor",
+					index = 14,
+					callback = run(function()
+						actions.delete_comment(buf)
+					end),
+					opts = { silent = true, nowait = true },
+				})
+			)
+			add(
+				review_actions,
 				item("ui.toggle_fold", {
 					desc = "Toggle review thread",
-					index = 14,
+					index = 15,
 					callback = run(function()
 						if not actions.toggle_thread(buf) then
 							pcall(vim.cmd.normal, { "za", bang = true })
@@ -446,7 +457,7 @@ function M.register_review(session, actions)
 				review_actions,
 				item("ui.toggle_all_folds", {
 					desc = "Toggle all review threads",
-					index = 15,
+					index = 16,
 					callback = run(function()
 						if not actions.toggle_all_threads() then
 							pcall(vim.cmd.normal, { "zA", bang = true })
@@ -482,7 +493,7 @@ function M.register_review(session, actions)
 			review_actions,
 			item("ui.open_in_browser", {
 				desc = "Open pull request in browser",
-				index = 16,
+				index = 17,
 				callback = run(actions.open_in_browser),
 				opts = { silent = true, nowait = true },
 			})
@@ -507,6 +518,7 @@ local REVIEW_CONTENT_ACTIONS = {
 	"pulls.review.toggle_resolved",
 	"pulls.review.add_pending_comment",
 	"pulls.review.add_comment",
+	"pulls.review.delete_comment",
 	"ui.toggle_fold",
 	"ui.toggle_all_folds",
 	"ui.open_in_browser",

--- a/lua/atlas/pulls/diff/shared/comments/init.lua
+++ b/lua/atlas/pulls/diff/shared/comments/init.lua
@@ -20,6 +20,7 @@ local comment_threads = require("atlas.ui.components.review_threads")
 ---@field toggle_task (fun())|nil
 ---@field toggle_resolved fun(buf: integer)
 ---@field add_comment fun(buf: integer, pending: boolean)
+---@field delete_comment fun(buf: integer)
 ---@field toggle_thread fun(buf: integer): boolean
 ---@field toggle_all_threads fun(): boolean
 ---@field jump_comment fun(buf: integer, direction: 1|-1)
@@ -681,6 +682,31 @@ end
 
 ---@param session AtlasReviewSession
 ---@param state AtlasReviewState
+---@param buf integer
+local function delete_comment_at_cursor(session, state, buf)
+	local threads = threads_at_cursor(session, state, buf)
+	if #threads == 0 then
+		view_notify(session, "info", "No comment at cursor")
+		return
+	end
+	if #threads > 1 then
+		open_thread(session, state, buf)
+		return
+	end
+
+	local comment = threads[1].comment
+	if not can_action(state, "delete", comment) then
+		view_notify(session, "info", "This comment cannot be deleted")
+		return
+	end
+	local context = action_context(session, state, comment)
+	if context then
+		actions.run(context, "delete", comment)
+	end
+end
+
+---@param session AtlasReviewSession
+---@param state AtlasReviewState
 local function register_keymaps(session, state)
 	if state.keymaps_registered then
 		return
@@ -734,6 +760,9 @@ local function register_keymaps(session, state)
 		end,
 		add_comment = function(buf, pending)
 			add_inline_comment(session, state, buf, pending)
+		end,
+		delete_comment = function(buf)
+			delete_comment_at_cursor(session, state, buf)
 		end,
 		toggle_thread = function(buf)
 			return toggle_at_cursor(session, state, buf)

--- a/spec/keymaps_spec.lua
+++ b/spec/keymaps_spec.lua
@@ -131,3 +131,35 @@ describe("atlas navigation keymaps", function()
 		assert.is_nil(ui_conflicts["j"])
 	end)
 end)
+
+describe("atlas pulls review delete_comment keymap", function()
+	before_each(function()
+		config.options.keymaps = deep_copy(shipped_keymaps)
+	end)
+
+	it("resolves the shipped default to dd", function()
+		assert.are.same({ "dd" }, keymaps.resolve("pulls.review.delete_comment"))
+	end)
+
+	it("supports remapping and disabling delete_comment", function()
+		config.options.keymaps.pulls.review.delete_comment = "gD"
+		assert.are.same({ "gD" }, keymaps.resolve("pulls.review.delete_comment"))
+
+		config.options.keymaps.pulls.review.delete_comment = false
+		assert.is_nil(keymaps.resolve("pulls.review.delete_comment"))
+	end)
+
+	it("does not conflict with the other shipped pulls.review keys", function()
+		local pulls_conflicts = keymaps.validate().pulls
+		assert.are.same({}, pulls_conflicts)
+	end)
+
+	it("detects a conflict when remapped onto an existing pulls.review key", function()
+		-- "C" is already taken by add_comment, so remapping delete_comment onto it
+		-- must be flagged rather than silently shadowing add_comment.
+		config.options.keymaps.pulls.review.delete_comment = "C"
+
+		local pulls_conflicts = keymaps.validate().pulls
+		assert.are.same({ "pulls.review.add_comment", "pulls.review.delete_comment" }, pulls_conflicts["C"])
+	end)
+end)


### PR DESCRIPTION
## Description

This PR adds the `delete_comment` in a PR review keymap (`dd`) that removes the comment under the cursor with a confirmation prompt. This change was tested with GitHub primarily.

## Changes

- Update the documentation files to include the new `delete_comment` keymap.
- Added the `delete_comment_at_cursor` function to handle the removal of comments with a confirmation prompt.
- Added unit tests for validating the new behaviour.

## Additional Notes

- Executed the `busted` command at the root of the repository to confirm that the tests are passing
- Tested the behaviour with GitHub and the process works properly locally in my setup. I only use this platform for PRs at the moment, so I can't confirm that it works for the other platforms like GitLab, etc.
- This PR only contains the delete comment functionality for now to reduce complexity. Looking at the other PRs I didn't see other opened PRs that provided this capability.
- Opened to adjust the default keymap for the `delete_comment` functionality as necessary, I went with the same keybindings setup as with vim.
- Side note, just wanted to mention that it's a great plugin that's much more modern look and feel than `octo.nvim`, keep up the good work!