### PR TITLE
feat: current_repo scope

### DIFF
--- a/lua/atlas/issues/providers/github/config.lua
+++ b/lua/atlas/issues/providers/github/config.lua
@@ -25,6 +25,7 @@
 
 ---@class AtlasGitHubIssuesViewConfig : IssuesViewConfig
 ---@field search string
+---@field current_repo boolean|nil
 
 ---@class AtlasGitHubIssuesBookmarksConfig
 ---@field key string|nil    -- default "S"

--- a/lua/atlas/issues/providers/github/init.lua
+++ b/lua/atlas/issues/providers/github/init.lua
@@ -5,6 +5,7 @@ local resolver = require("atlas.providers.resolve")
 local request_scope = require("atlas.core.requests")
 local issue_cache = require("atlas.issues.providers.github.api.cache")
 local notifications_api = require("atlas.providers.github.notifications").new("issues")
+local git = require("atlas.core.git")
 
 ---@param view IssuesViewConfig
 ---@param opts IssuesFetchOpts
@@ -282,6 +283,24 @@ function M.fetch_activity(issue, opts, on_done)
 	end, { force_load = opts and opts.force_load == true or false })
 end
 
+---@param view AtlasGitHubIssuesViewConfig
+---@return AtlasGitHubIssuesViewConfig
+local function resolve_cur_repo(view)
+    if not view.current_repo then
+        return view
+    end
+    local root = git.repo_root()
+    local info = git.local_repository(root)
+    if not info then
+        return view
+    end
+    local resolved = vim.tbl_extend("force", {}, view)
+    local additional = (view.search and vim.search ~= "") and (" " .. view.search) or ""
+    resolved.search = string.format("repo:%s%s", info.slug, additional)
+    return resolved
+end
+
+
 ---@return AtlasGitHubIssuesViewConfig[]
 function M.views()
 	local cli = require("atlas.providers.github.client").issues
@@ -293,7 +312,11 @@ function M.views()
 			search = "assignee:@me is:open",
 		},
 	}
-	return views
+    local resolved = {}
+    for i, view in ipairs(views) do
+        resolved[i] = resolve_cur_repo(view)
+    end
+    return resolved
 end
 
 local renderer = require("atlas.issues.providers.github.ui.renderer")

--- a/lua/atlas/issues/providers/github/init.lua
+++ b/lua/atlas/issues/providers/github/init.lua
@@ -286,20 +286,19 @@ end
 ---@param view AtlasGitHubIssuesViewConfig
 ---@return AtlasGitHubIssuesViewConfig
 local function resolve_cur_repo(view)
-    if not view.current_repo then
-        return view
-    end
-    local root = git.repo_root()
-    local info = git.local_repository(root)
-    if not info then
-        return view
-    end
-    local resolved = vim.tbl_extend("force", {}, view)
-    local additional = (view.search and vim.search ~= "") and (" " .. view.search) or ""
-    resolved.search = string.format("repo:%s%s", info.slug, additional)
-    return resolved
+	if not view.current_repo then
+		return view
+	end
+	local root = git.repo_root()
+	local info = git.local_repository(root)
+	if not info then
+		return view
+	end
+	local resolved = vim.tbl_extend("force", {}, view)
+	local additional = (view.search and vim.search ~= "") and (" " .. view.search) or ""
+	resolved.search = string.format("repo:%s%s", info.slug, additional)
+	return resolved
 end
-
 
 ---@return AtlasGitHubIssuesViewConfig[]
 function M.views()
@@ -312,11 +311,11 @@ function M.views()
 			search = "assignee:@me is:open",
 		},
 	}
-    local resolved = {}
-    for i, view in ipairs(views) do
-        resolved[i] = resolve_cur_repo(view)
-    end
-    return resolved
+	local resolved = {}
+	for i, view in ipairs(views) do
+		resolved[i] = resolve_cur_repo(view)
+	end
+	return resolved
 end
 
 local renderer = require("atlas.issues.providers.github.ui.renderer")

--- a/lua/atlas/issues/providers/gitlab/api/issues.lua
+++ b/lua/atlas/issues/providers/gitlab/api/issues.lua
@@ -38,7 +38,7 @@ end
 ---@return { cancel: fun() }|nil
 function M.list_issues(view, opts, on_done)
 	opts = opts or {}
-    local scoped_project = view.project ~= nil and tostring(view.project) ~= ""
+	local scoped_project = view.project ~= nil and tostring(view.project) ~= ""
 	local params = {
 		scope = view.scope or "assigned_to_me",
 		state = view.state or "opened",
@@ -67,7 +67,9 @@ function M.list_issues(view, opts, on_done)
 		end
 	end
 
-	local endpoint = ( scoped_project and string.format("/projects/%s/issues", service.url_encode(tostring(view.project))) or "/issues" ) .. build_query(params)
+	local endpoint = (
+		scoped_project and string.format("/projects/%s/issues", service.url_encode(tostring(view.project))) or "/issues"
+	) .. build_query(params)
 	local cache_key = LIST_CACHE_PREFIX .. endpoint
 
 	if not opts.force_load then

--- a/lua/atlas/issues/providers/gitlab/api/issues.lua
+++ b/lua/atlas/issues/providers/gitlab/api/issues.lua
@@ -38,6 +38,7 @@ end
 ---@return { cancel: fun() }|nil
 function M.list_issues(view, opts, on_done)
 	opts = opts or {}
+    local scoped_project = view.project ~= nil and tostring(view.project) ~= ""
 	local params = {
 		scope = view.scope or "assigned_to_me",
 		state = view.state or "opened",
@@ -66,7 +67,7 @@ function M.list_issues(view, opts, on_done)
 		end
 	end
 
-	local endpoint = "/issues" .. build_query(params)
+	local endpoint = ( scoped_project and string.format("/projects/%s/issues", service.url_encode(tostring(view.project))) or "/issues" ) .. build_query(params)
 	local cache_key = LIST_CACHE_PREFIX .. endpoint
 
 	if not opts.force_load then

--- a/lua/atlas/issues/providers/gitlab/config.lua
+++ b/lua/atlas/issues/providers/gitlab/config.lua
@@ -47,6 +47,7 @@
 ---@field extra_params table<string, string>|nil
 
 ---@class AtlasGitLabIssuesViewConfig : IssuesViewConfig, AtlasGitLabIssuesSearchConfig
+---@field current_repo boolean|nil
 
 ---@class AtlasGitLabIssuesBookmarksConfig
 ---@field key string|nil    -- default "S"

--- a/lua/atlas/issues/providers/gitlab/init.lua
+++ b/lua/atlas/issues/providers/gitlab/init.lua
@@ -1,6 +1,7 @@
 local GITLAB_REACTION_OPTIONS = require("atlas.ui.shared.emojis").gitlab()
 local resolver = require("atlas.providers.resolve")
 local notifications_api = require("atlas.providers.gitlab.notifications").new("issues")
+local git = require("atlas.core.git")
 
 ---@class GitLabIssuesProvider : IssuesProvider
 local M = {}
@@ -160,6 +161,24 @@ function M.add_reaction(issue, comment, key, on_done)
 	return require("atlas.issues.providers.gitlab.api.notes").add_reaction(issue_key, comment.id, key, on_done)
 end
 
+---@param view AtlasGitLabIssuesViewConfig
+---@return AtlasGitLabIssuesViewConfig
+local function resolve_cur_repo(view)
+    if not view.current_repo then
+        return view
+    end
+    local root = git.repo_root()
+    local info = git.local_repository(root)
+    if not info then
+        return view
+    end
+    local resolved = vim.tbl_extend("force", {}, view)
+    resolved.project = info.slug
+    resolved.scope = view.scope or "all"
+    return resolved
+end
+
+
 ---@return AtlasGitLabIssuesViewConfig[]
 function M.views()
 	local cfg = require("atlas.providers.gitlab.client").issues.gitlab_config()
@@ -168,7 +187,11 @@ function M.views()
 			{ name = "Assigned", key = "1", scope = "assigned_to_me", state = "opened" },
 			{ name = "Created", key = "2", scope = "created_by_me", state = "opened" },
 		}
-	return views
+    local resolved = {}
+    for i, view in ipairs(views) do
+        resolved[i] = resolve_cur_repo(view)
+    end
+    return resolved
 end
 
 local renderer = require("atlas.issues.providers.gitlab.ui.renderer")

--- a/lua/atlas/issues/providers/gitlab/init.lua
+++ b/lua/atlas/issues/providers/gitlab/init.lua
@@ -164,20 +164,19 @@ end
 ---@param view AtlasGitLabIssuesViewConfig
 ---@return AtlasGitLabIssuesViewConfig
 local function resolve_cur_repo(view)
-    if not view.current_repo then
-        return view
-    end
-    local root = git.repo_root()
-    local info = git.local_repository(root)
-    if not info then
-        return view
-    end
-    local resolved = vim.tbl_extend("force", {}, view)
-    resolved.project = info.slug
-    resolved.scope = view.scope or "all"
-    return resolved
+	if not view.current_repo then
+		return view
+	end
+	local root = git.repo_root()
+	local info = git.local_repository(root)
+	if not info then
+		return view
+	end
+	local resolved = vim.tbl_extend("force", {}, view)
+	resolved.project = info.slug
+	resolved.scope = view.scope or "all"
+	return resolved
 end
-
 
 ---@return AtlasGitLabIssuesViewConfig[]
 function M.views()
@@ -187,11 +186,11 @@ function M.views()
 			{ name = "Assigned", key = "1", scope = "assigned_to_me", state = "opened" },
 			{ name = "Created", key = "2", scope = "created_by_me", state = "opened" },
 		}
-    local resolved = {}
-    for i, view in ipairs(views) do
-        resolved[i] = resolve_cur_repo(view)
-    end
-    return resolved
+	local resolved = {}
+	for i, view in ipairs(views) do
+		resolved[i] = resolve_cur_repo(view)
+	end
+	return resolved
 end
 
 local renderer = require("atlas.issues.providers.gitlab.ui.renderer")

--- a/lua/atlas/pulls/providers/bitbucket/config.lua
+++ b/lua/atlas/pulls/providers/bitbucket/config.lua
@@ -42,6 +42,7 @@
 ---@field repos AtlasBitbucketRepoRef[]|nil
 ---@field filter? fun(pr: PullRequest, ctx: { user: PullsUser|nil }): boolean|nil
 ---@field status? "OPEN"|"MERGED"|"DECLINED"|"SUPERSEDED"
+---@field current_repo boolean|nil
 
 ---@class AtlasBitbucketConfig
 ---@field user string

--- a/lua/atlas/pulls/providers/bitbucket/init.lua
+++ b/lua/atlas/pulls/providers/bitbucket/init.lua
@@ -9,6 +9,7 @@ local reviews_api = require("atlas.pulls.providers.bitbucket.api.reviews")
 local tasks_api = require("atlas.pulls.providers.bitbucket.api.tasks")
 local users_api = require("atlas.pulls.providers.bitbucket.api.users")
 local resolver = require("atlas.providers.resolve")
+local git = require("atlas.core.git")
 
 ---@param value string
 ---@param parsed AtlasParsedUrl|nil
@@ -198,6 +199,23 @@ local function fetch_repo_tags(repo, opts, on_done)
 	return repositories_api.fetch_tags(tostring(tags.href or ""), opts, on_done)
 end
 
+
+---@param view AtlasBitbucketViewConfig
+---@return AtlasBitbucketRepoRef[]|nil
+local function resolve_cur_repo(view)
+    if not view.current_repo then
+        return view
+    end
+    local root = git.repo_root()
+    local info = git.local_repository(root)
+    if not info then
+        return view
+    end
+    return { { workspace = info.owner, repo = info.repo } }
+end
+
+
+
 ---@return AtlasBitbucketViewConfig[]
 local function views()
 	local config = (((require("atlas.config").options or {}).pulls or {}).providers or {}).bitbucket
@@ -207,7 +225,7 @@ local function views()
 			name = view.name,
 			key = view.key,
 			layout = view.layout,
-			repos = view.repos,
+			repos = resolve_cur_repo(view),
 			filter = view.filter,
 		})
 	end

--- a/lua/atlas/pulls/providers/bitbucket/init.lua
+++ b/lua/atlas/pulls/providers/bitbucket/init.lua
@@ -199,22 +199,19 @@ local function fetch_repo_tags(repo, opts, on_done)
 	return repositories_api.fetch_tags(tostring(tags.href or ""), opts, on_done)
 end
 
-
 ---@param view AtlasBitbucketViewConfig
 ---@return AtlasBitbucketRepoRef[]|nil
 local function resolve_cur_repo(view)
-    if not view.current_repo then
-        return view
-    end
-    local root = git.repo_root()
-    local info = git.local_repository(root)
-    if not info then
-        return view
-    end
-    return { { workspace = info.owner, repo = info.repo } }
+	if not view.current_repo then
+		return view
+	end
+	local root = git.repo_root()
+	local info = git.local_repository(root)
+	if not info then
+		return view
+	end
+	return { { workspace = info.owner, repo = info.repo } }
 end
-
-
 
 ---@return AtlasBitbucketViewConfig[]
 local function views()

--- a/lua/atlas/pulls/providers/github/config.lua
+++ b/lua/atlas/pulls/providers/github/config.lua
@@ -26,7 +26,7 @@
 
 ---@class AtlasGitHubViewConfig : AtlasPullsViewConfig
 ---@field search string
----@field current_repo boolean
+---@field current_repo boolean|nil
 
 ---@class AtlasGitHubBookmarksConfig
 ---@field key string|nil    -- default "S"

--- a/lua/atlas/pulls/providers/github/config.lua
+++ b/lua/atlas/pulls/providers/github/config.lua
@@ -26,6 +26,7 @@
 
 ---@class AtlasGitHubViewConfig : AtlasPullsViewConfig
 ---@field search string
+---@field current_repo boolean
 
 ---@class AtlasGitHubBookmarksConfig
 ---@field key string|nil    -- default "S"

--- a/lua/atlas/pulls/providers/github/init.lua
+++ b/lua/atlas/pulls/providers/github/init.lua
@@ -148,18 +148,18 @@ end
 ---@param view AtlasGitHubViewConfig
 ---@return AtlasGitHubViewConfig
 local function resolve_cur_repo(view)
-    if not view.current_repo then
-        return view
-    end
-    local root = git.repo_root()
-    local info = git.local_repository(root)
-    if not info then
-        return view
-    end
-    local resolved = vim.tbl_extend("force", {}, view)
-    local additional = (view.search and vim.search ~= "") and (" " .. view.search) or ""
-    resolved.search = string.format("repo:%s%s", info.slug, additional)
-    return resolved
+	if not view.current_repo then
+		return view
+	end
+	local root = git.repo_root()
+	local info = git.local_repository(root)
+	if not info then
+		return view
+	end
+	local resolved = vim.tbl_extend("force", {}, view)
+	local additional = (view.search and vim.search ~= "") and (" " .. view.search) or ""
+	resolved.search = string.format("repo:%s%s", info.slug, additional)
+	return resolved
 end
 
 ---@return AtlasGitHubViewConfig[]
@@ -168,11 +168,11 @@ local function views()
 	---@cast config AtlasGitHubConfig
 	local configured = type(config.views) == "table" and #config.views > 0 and config.views
 		or { { name = "Me", key = "1", search = "involves:@me", layout = "compact" } }
-    local resolved = {}
-    for i, view in ipairs(configured) do
-        resolved[i] = resolve_cur_repo(view)
-    end
-    return resolved
+	local resolved = {}
+	for i, view in ipairs(configured) do
+		resolved[i] = resolve_cur_repo(view)
+	end
+	return resolved
 end
 
 ---@param value string

--- a/lua/atlas/pulls/providers/github/init.lua
+++ b/lua/atlas/pulls/providers/github/init.lua
@@ -12,6 +12,7 @@ local repositories_api = require("atlas.pulls.providers.github.api.repositories"
 local reviews_api = require("atlas.pulls.providers.github.api.reviews")
 local users_api = require("atlas.pulls.providers.github.api.users")
 local resolver = require("atlas.providers.resolve")
+local git = require("atlas.core.git")
 
 ---@param on_done fun(user: PullsUser|nil, err: string|nil)
 ---@return { cancel: fun() }|nil
@@ -144,13 +145,34 @@ local function add_reaction(pr, comment, key, on_done)
 	end)
 end
 
+---@param view AtlasGitHubViewConfig
+---@return AtlasGitHubViewConfig
+local function resolve_cur_repo(view)
+    if not view.current_repo then
+        return view
+    end
+    local root = git.repo_root()
+    local info = git.local_repository(root)
+    if not info then
+        return view
+    end
+    local resolved = vim.tbl_extend("force", {}, view)
+    local additional = (view.search and vim.search ~= "") and (" " .. view.search) or ""
+    resolved.search = string.format("repo:%s%s", info.slug, additional)
+    return resolved
+end
+
 ---@return AtlasGitHubViewConfig[]
 local function views()
 	local config = ((require("atlas.config").options.pulls or {}).providers or {}).github or {}
 	---@cast config AtlasGitHubConfig
 	local configured = type(config.views) == "table" and #config.views > 0 and config.views
 		or { { name = "Me", key = "1", search = "involves:@me", layout = "compact" } }
-	return configured
+    local resolved = {}
+    for i, view in ipairs(configured) do
+        resolved[i] = resolve_cur_repo(view)
+    end
+    return resolved
 end
 
 ---@param value string

--- a/lua/atlas/pulls/providers/gitlab/config.lua
+++ b/lua/atlas/pulls/providers/gitlab/config.lua
@@ -48,6 +48,7 @@
 ---@field extra_params table<string, string>|nil
 
 ---@class AtlasGitLabPullsViewConfig : AtlasPullsViewConfig, AtlasGitLabPullsSearchConfig
+---@field current_repo boolean|nil
 
 ---@class AtlasGitLabPullsBookmarksConfig
 ---@field key string|nil    -- default "S"

--- a/lua/atlas/pulls/providers/gitlab/init.lua
+++ b/lua/atlas/pulls/providers/gitlab/init.lua
@@ -163,7 +163,7 @@ local function resolve_cur_repo(view)
     end
     local resolved = vim.tbl_extend("force", {}, view)
     resolved.project = info.slug
-    resolved.scop = view.scope or "all"
+    resolved.scope = view.scope or "all"
     return resolved
 end
 

--- a/lua/atlas/pulls/providers/gitlab/init.lua
+++ b/lua/atlas/pulls/providers/gitlab/init.lua
@@ -11,6 +11,7 @@ local reviews_api = require("atlas.pulls.providers.gitlab.api.reviews")
 local service = require("atlas.providers.gitlab.client").pulls
 local users_api = require("atlas.pulls.providers.gitlab.api.users")
 local resolver = require("atlas.providers.resolve")
+local git = require("atlas.core.git")
 
 ---@param view AtlasPullsViewConfig
 ---@param opts PullsFetchOpts
@@ -149,6 +150,25 @@ local function create_pr(opts, on_done)
 	end)
 end
 
+---@param view AtlasGitLabPullsViewConfig
+---@return AtlasGitLabPullsViewConfig
+local function resolve_cur_repo(view)
+    if not view.current_repo then
+        return view
+    end
+    local root = git.repo_root()
+    local info = git.local_repository(root)
+    if not info then
+        return view
+    end
+    local resolved = vim.tbl_extend("force", {}, view)
+    resolved.project = info.slug
+    resolved.scop = view.scope or "all"
+    return resolved
+end
+
+
+
 ---@return AtlasGitLabPullsViewConfig[]
 local function views()
 	local config = service.gitlab_config()
@@ -157,7 +177,11 @@ local function views()
 			{ name = "Assigned", key = "1", scope = "assigned_to_me", state = "opened" },
 			{ name = "Created", key = "2", scope = "created_by_me", state = "opened" },
 		}
-	return configured
+    local resolved = {}
+    for i, view in ipairs(configured) do
+        resolved[i] = resolve_cur_repo(view)
+    end
+    return resolved
 end
 
 ---@param value string

--- a/lua/atlas/pulls/providers/gitlab/init.lua
+++ b/lua/atlas/pulls/providers/gitlab/init.lua
@@ -153,21 +153,19 @@ end
 ---@param view AtlasGitLabPullsViewConfig
 ---@return AtlasGitLabPullsViewConfig
 local function resolve_cur_repo(view)
-    if not view.current_repo then
-        return view
-    end
-    local root = git.repo_root()
-    local info = git.local_repository(root)
-    if not info then
-        return view
-    end
-    local resolved = vim.tbl_extend("force", {}, view)
-    resolved.project = info.slug
-    resolved.scope = view.scope or "all"
-    return resolved
+	if not view.current_repo then
+		return view
+	end
+	local root = git.repo_root()
+	local info = git.local_repository(root)
+	if not info then
+		return view
+	end
+	local resolved = vim.tbl_extend("force", {}, view)
+	resolved.project = info.slug
+	resolved.scope = view.scope or "all"
+	return resolved
 end
-
-
 
 ---@return AtlasGitLabPullsViewConfig[]
 local function views()
@@ -177,11 +175,11 @@ local function views()
 			{ name = "Assigned", key = "1", scope = "assigned_to_me", state = "opened" },
 			{ name = "Created", key = "2", scope = "created_by_me", state = "opened" },
 		}
-    local resolved = {}
-    for i, view in ipairs(configured) do
-        resolved[i] = resolve_cur_repo(view)
-    end
-    return resolved
+	local resolved = {}
+	for i, view in ipairs(configured) do
+		resolved[i] = resolve_cur_repo(view)
+	end
+	return resolved
 end
 
 ---@param value string


### PR DESCRIPTION
Add the ability to add the option "current_repo" to pull and issue views, which allows to create views that only list pull requests/issues in the repo that is currently opened, which is useful when developing within a repo and wanting to inspect its PRs etc.
The changes only add a few lines of code since most of its functionality is already present in the code base, just not combined in a way that it creates this feature.

Pull Requests:
- [x] GitHub
- [x] GitLab
- [x] BitBucket

Issues:
- [x] GitHub
- [x] GitLab
~~Jira~~ (Probably skipped (see conversation below))