### PR TITLE
fix(highlights): update the highlights configuration to respect colorscheme

### DIFF
--- a/lua/atlas/issues/ui/highlights.lua
+++ b/lua/atlas/issues/ui/highlights.lua
@@ -19,7 +19,7 @@ local groups = {
 function M.setup()
 	shared.setup()
 	for name, opts in pairs(groups) do
-		vim.api.nvim_set_hl(0, name, opts)
+		vim.api.nvim_set_hl(0, name, vim.tbl_extend("force", opts, { default = true }))
 	end
 end
 

--- a/lua/atlas/pulls/ui/highlights.lua
+++ b/lua/atlas/pulls/ui/highlights.lua
@@ -28,7 +28,7 @@ local groups = {
 function M.setup()
 	shared.setup()
 	for name, opts in pairs(groups) do
-		vim.api.nvim_set_hl(0, name, opts)
+		vim.api.nvim_set_hl(0, name, vim.tbl_extend("force", opts, { default = true }))
 	end
 end
 

--- a/lua/atlas/ui/shared/highlights.lua
+++ b/lua/atlas/ui/shared/highlights.lua
@@ -67,14 +67,14 @@ local groups = {
 
 function M.setup()
 	for name, opts in pairs(groups) do
-		vim.api.nvim_set_hl(0, name, opts)
+		vim.api.nvim_set_hl(0, name, vim.tbl_extend("force", opts, { default = true }))
 	end
 
 	for idx, color in ipairs(dynamic_palette) do
 		local fg_name = string.format("AtlasDynColor%02d", idx)
 		local bg_name = string.format("AtlasDynBgColor%02d", idx)
-		vim.api.nvim_set_hl(0, fg_name, { fg = color })
-		vim.api.nvim_set_hl(0, bg_name, { fg = "#1e1e2e", bg = color })
+		vim.api.nvim_set_hl(0, fg_name, { fg = color, default = true })
+		vim.api.nvim_set_hl(0, bg_name, { fg = "#1e1e2e", bg = color, default = true })
 	end
 end
 

--- a/spec/issues/ui/highlights_spec.lua
+++ b/spec/issues/ui/highlights_spec.lua
@@ -1,0 +1,38 @@
+local highlights = require("atlas.issues.ui.highlights")
+
+describe("issues.ui.highlights", function()
+	before_each(function()
+		vim.api.__reset_highlights()
+	end)
+
+	it("defines its groups when nothing has set them yet", function()
+		highlights.setup()
+
+		assert.are.same({ fg = "#a6e3a1", bold = true, default = true }, vim.api.nvim_get_hl(0, { name = "AtlasIssueOpen" }))
+	end)
+
+	it("does not clobber a group a colorscheme already defined", function()
+		vim.api.nvim_set_hl(0, "AtlasIssueOpen", { fg = "#ff00ff" })
+
+		highlights.setup()
+
+		assert.are.same({ fg = "#ff00ff" }, vim.api.nvim_get_hl(0, { name = "AtlasIssueOpen" }))
+	end)
+
+	it("keeps a colorscheme override across repeated setup() calls", function()
+		-- Regression test: setup() re-runs on every issues view open, so a
+		-- colorscheme's override must survive more than the first call.
+		vim.api.nvim_set_hl(0, "AtlasJiraKey", { fg = "#111111" })
+
+		highlights.setup()
+		highlights.setup()
+
+		assert.are.same({ fg = "#111111" }, vim.api.nvim_get_hl(0, { name = "AtlasJiraKey" }))
+	end)
+
+	it("also sets up the shared groups it depends on", function()
+		highlights.setup()
+
+		assert.is_not_nil(vim.api.nvim_get_hl(0, { name = "AtlasJiraTheme" }).bg)
+	end)
+end)

--- a/spec/issues/ui/highlights_spec.lua
+++ b/spec/issues/ui/highlights_spec.lua
@@ -8,7 +8,10 @@ describe("issues.ui.highlights", function()
 	it("defines its groups when nothing has set them yet", function()
 		highlights.setup()
 
-		assert.are.same({ fg = "#a6e3a1", bold = true, default = true }, vim.api.nvim_get_hl(0, { name = "AtlasIssueOpen" }))
+		assert.are.same(
+			{ fg = "#a6e3a1", bold = true, default = true },
+			vim.api.nvim_get_hl(0, { name = "AtlasIssueOpen" })
+		)
 	end)
 
 	it("does not clobber a group a colorscheme already defined", function()

--- a/spec/pulls/ui/highlights_spec.lua
+++ b/spec/pulls/ui/highlights_spec.lua
@@ -1,0 +1,36 @@
+local highlights = require("atlas.pulls.ui.highlights")
+
+describe("pulls.ui.highlights", function()
+	before_each(function()
+		vim.api.__reset_highlights()
+	end)
+
+	it("defines its groups when nothing has set them yet", function()
+		highlights.setup()
+
+		assert.are.same({ fg = "#86efac", default = true }, vim.api.nvim_get_hl(0, { name = "AtlasPROpen" }))
+	end)
+
+	it("does not clobber a group a colorscheme already defined", function()
+		vim.api.nvim_set_hl(0, "AtlasPROpen", { fg = "#00ff00" })
+
+		highlights.setup()
+
+		assert.are.same({ fg = "#00ff00" }, vim.api.nvim_get_hl(0, { name = "AtlasPROpen" }))
+	end)
+
+	it("keeps a colorscheme override across repeated setup() calls", function()
+		vim.api.nvim_set_hl(0, "AtlasPRMerged", { fg = "#654321" })
+
+		highlights.setup()
+		highlights.setup()
+
+		assert.are.same({ fg = "#654321" }, vim.api.nvim_get_hl(0, { name = "AtlasPRMerged" }))
+	end)
+
+	it("also sets up the shared groups it depends on", function()
+		highlights.setup()
+
+		assert.is_not_nil(vim.api.nvim_get_hl(0, { name = "AtlasGitHubTheme" }).bg)
+	end)
+end)

--- a/spec/support/vim_stub.lua
+++ b/spec/support/vim_stub.lua
@@ -59,11 +59,43 @@ _G.vim = {
 		return value:match("^%s*(.-)%s*$")
 	end,
 
-	api = {
-		nvim_create_namespace = function()
-			return 1
-		end,
-	},
+	api = (function()
+		-- Fakes just enough of nvim_set_hl/nvim_get_hl to test highlight setup
+		-- code: `default = true` must behave like `:highlight default`, i.e. it
+		-- only fills a group in when nothing has defined it yet.
+		local highlights = {}
+
+		return {
+			nvim_create_namespace = function()
+				return 1
+			end,
+
+			nvim_set_hl = function(_, name, val)
+				if val.default and highlights[name] ~= nil then
+					return
+				end
+				highlights[name] = val
+			end,
+
+			nvim_get_hl = function(_, filter)
+				local name = filter and filter.name
+				local existing = name and highlights[name]
+				if not existing then
+					return {}
+				end
+				local copy = {}
+				for k, v in pairs(existing) do
+					copy[k] = v
+				end
+				return copy
+			end,
+
+			-- Test-only: clears recorded highlights between specs.
+			__reset_highlights = function()
+				highlights = {}
+			end,
+		}
+	end)(),
 
 	-- vim.tbl_extend(behavior, ...) -> shallow merge honoring "keep"/"force"/"error"
 	tbl_extend = function(behavior, ...)

--- a/spec/ui/shared/highlights_spec.lua
+++ b/spec/ui/shared/highlights_spec.lua
@@ -8,7 +8,10 @@ describe("ui.shared.highlights", function()
 	it("defines its groups when nothing has set them yet", function()
 		highlights.setup()
 
-		assert.are.same({ bg = "#1f2328", fg = "#f0f6fc", bold = true, default = true }, vim.api.nvim_get_hl(0, { name = "AtlasGitHubTheme" }))
+		assert.are.same(
+			{ bg = "#1f2328", fg = "#f0f6fc", bold = true, default = true },
+			vim.api.nvim_get_hl(0, { name = "AtlasGitHubTheme" })
+		)
 	end)
 
 	it("does not clobber a group a colorscheme already defined", function()

--- a/spec/ui/shared/highlights_spec.lua
+++ b/spec/ui/shared/highlights_spec.lua
@@ -1,0 +1,44 @@
+local highlights = require("atlas.ui.shared.highlights")
+
+describe("ui.shared.highlights", function()
+	before_each(function()
+		vim.api.__reset_highlights()
+	end)
+
+	it("defines its groups when nothing has set them yet", function()
+		highlights.setup()
+
+		assert.are.same({ bg = "#1f2328", fg = "#f0f6fc", bold = true, default = true }, vim.api.nvim_get_hl(0, { name = "AtlasGitHubTheme" }))
+	end)
+
+	it("does not clobber a group a colorscheme already defined", function()
+		-- Simulates a colorscheme (or user config) overriding an Atlas group
+		-- before Atlas's own setup() runs.
+		vim.api.nvim_set_hl(0, "AtlasGitHubTheme", { fg = "#ffffff" })
+
+		highlights.setup()
+
+		assert.are.same({ fg = "#ffffff" }, vim.api.nvim_get_hl(0, { name = "AtlasGitHubTheme" }))
+	end)
+
+	it("keeps a colorscheme override across repeated setup() calls", function()
+		-- setup() re-runs every time a pulls/issues view opens, so the
+		-- override must survive more than one call, not just the first.
+		vim.api.nvim_set_hl(0, "AtlasBorder", { fg = "#123456" })
+
+		highlights.setup()
+		highlights.setup()
+
+		assert.are.same({ fg = "#123456" }, vim.api.nvim_get_hl(0, { name = "AtlasBorder" }))
+	end)
+
+	it("defines the dynamic palette groups as defaults too", function()
+		vim.api.nvim_set_hl(0, "AtlasDynColor01", { fg = "#custom" })
+
+		highlights.setup()
+
+		assert.are.same({ fg = "#custom" }, vim.api.nvim_get_hl(0, { name = "AtlasDynColor01" }))
+		-- A dynamic group nothing overrode still gets Atlas's fallback color.
+		assert.is_not_nil(vim.api.nvim_get_hl(0, { name = "AtlasDynBgColor01" }).bg)
+	end)
+end)


### PR DESCRIPTION
## Overview

This PR fixes the highlights configuration for the plugin to prevent a custom colorscheme overlap. I faced this issue when opening the details pane where the theme would switch back and forth between my colorscheme and a an external one.

## Changes

- Updated the highlights configuration to not overlap the existing colorscheme theme.
- Added tests to the `spec` for validating the new configuration with a custom colorscheme.

## Additional Notes

- The unit tests are successful and they all pass using the `busted` CLI tool.
- Tested the configuration locally on this branch and it's working properly for me, my colorscheme highlights are being taken into account.