### PR TITLE
feat(review): lsp attached pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,27 @@ My dotfiles include a [Pi extension that wraps this script](https://github.com/e
 
 </details>
 
+<details>
+<summary><strong>LSP for Reviews</strong> - attach LSP to the new side of a diff</summary>
+
+Both sides of a pull request diff are normally built from Git revisions, and Neovim does not attach language servers to such buffers. Set `pulls.diff.lsp.enabled` to attach them to the new side:
+
+```lua
+pulls = { diff = { lsp = { enabled = true } } }
+```
+
+Atlas then creates a detached worktree at the pull request head and opens the new side from it, so those buffers are real files that language servers, `gd`, and hover all work, if there are no competing mappings. Your checkout and current branch are untouched. The old side stays a revision buffer without a language server.
+
+The worktree lives under `stdpath("cache")/atlas/worktrees` and is removed when the diff closes; `pulls.diff.lsp.dir` overrides the location with a path or a function. Files with no counterpart in the worktree (deleted files, binaries, submodules) fall back to revision buffers.
+
+A fresh worktree has no `node_modules`, `.venv`, or other build output, so servers that need them resolve nothing. List those directories in `pulls.diff.lsp.link` to symlink them from your checkout.
+
+The linked directories are read from the repository Atlas diffs against. That is your local clone when Neovim is inside it, or the path mapped in repo_config.paths. Otherwise Atlas diffs against its own cache clone, which has no working tree, and every link entry is skipped.
+
+They are the same directories on disk, so a server that writes into them writes into your project.
+
+</details>
+
 ### Also included
 
 <details>
@@ -354,6 +375,18 @@ pulls = {
     layout = "inline", -- "inline" or "side-by-side".
     compact = true, -- Start with only changed hunks and surrounding context visible.
     compact_context_lines = 3, -- Context lines shown around hunks in compact mode.
+    lsp = {
+      -- Back the new side of the diff with a detached worktree at the PR head so it is made of
+      -- real files and your language servers attach to it (AtlasDiff only). Off by default.
+      enabled = false,
+      -- Where the worktree lives. Defaults to `stdpath("cache")/atlas/worktrees/<repo>-<sha>`.
+      -- May be an absolute path, or a function receiving
+      -- { repo_root, repo_full_name, pr_id, head_sha, default } that returns a path or nil.
+      dir = nil,
+      -- Directories symlinked from your checkout into the worktree so servers can resolve
+      -- dependencies. These are the same directories on disk, not copies.
+      link = {}, -- e.g. { "node_modules", ".venv" }
+    },
     explorer = {
       grouped = true, -- Group changed files by directory.
       hidden = false,

--- a/doc/atlas.txt
+++ b/doc/atlas.txt
@@ -278,6 +278,11 @@ PULLS CONFIGURATION                              *atlas-pulls-configuration*
         layout = "inline", -- "inline" or "side-by-side"
         compact = true, -- initially show hunks plus surrounding context
         compact_context_lines = 3, -- context lines around hunks in compact mode
+        lsp = {
+          enabled = false, -- real files on the new side, so LSP attaches
+          dir = nil,       -- absolute path or fun(ctx): string|nil
+          link = {},       -- e.g. { "node_modules", ".venv" }
+        },
         explorer = {
           grouped = true, -- group changed files by directory
           hidden = false,

--- a/lua/atlas/config.lua
+++ b/lua/atlas/config.lua
@@ -44,6 +44,15 @@
 
 ---@alias AtlasPullsDiffOpenCommand "AtlasDiff"|"DiffviewOpen"|"CodeDiff"
 
+-- Backs the diff with a detached worktree at the PR head so the new side is a real file buffer and
+-- language servers attach to it. `dir` receives an AtlasWorktreeContext and may return nil to keep
+-- the default location. `link` names directories symlinked from the main checkout (node_modules,
+-- .venv, ...) so servers can resolve dependencies; they are the same directories on disk.
+---@class AtlasPullsDiffLspConfig
+---@field enabled boolean|nil
+---@field dir string|(fun(ctx: AtlasWorktreeContext): string|nil)|nil
+---@field link string[]|nil
+
 ---@class AtlasPullsDiffConfig
 ---@field open_cmd AtlasPullsDiffOpenCommand|string|nil
 ---@field layout "side-by-side"|"inline"|nil
@@ -53,6 +62,7 @@
 ---@field comment_display "virtual_lines"|"virtual_text"|nil
 ---@field explorer AtlasPullsDiffExplorerConfig|nil
 ---@field review_panel AtlasPullsDiffReviewPanelConfig|nil
+---@field lsp AtlasPullsDiffLspConfig|nil
 
 ---@class AtlasPullsCommentTemplate
 ---@field label string
@@ -168,6 +178,12 @@ M.options = {
 			comment_display = "virtual_lines",
 			review_panel = {
 				height = 10,
+			},
+			lsp = {
+				enabled = false,
+				dir = nil,
+				-- Keep empty: setup() deep extends, which merges lists element-wise.
+				link = {},
 			},
 			explorer = {
 				grouped = true,

--- a/lua/atlas/core/git/worktree.lua
+++ b/lua/atlas/core/git/worktree.lua
@@ -1,0 +1,587 @@
+local M = {}
+
+local core_git = require("atlas.core.git")
+local logger = require("atlas.core.logger")
+
+local CACHE_SEGMENTS = "atlas/worktrees"
+local STALE_SECONDS = 7 * 24 * 60 * 60 -- one week
+local MAX_SLUG_LENGTH = 60
+local SHA_LENGTH = 12
+
+---@param value any
+---@return string
+local function trim(value)
+	return (tostring(value or ""):gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+---@param path string
+---@return string
+local function normalize_separators(path)
+	return (path:gsub("\\", "/"))
+end
+
+-- Last path segment, ignoring trailing separators. Kept free of vim.fn so it stays unit-testable.
+---@param path string
+---@return string
+local function basename(path)
+	local normalized = normalize_separators(trim(path)):gsub("/+$", "") -- remove trailing slashes
+	return normalized:match("([^/]+)$") or normalized
+end
+
+---@param value string
+---@return string
+local function slugify(value)
+	-- "My Weird / Path" -> "my-weird-path"
+	local slug = normalize_separators(trim(value)):lower():gsub("[^%w%-_]+", "-"):gsub("%-+", "-")
+	slug = slug:gsub("^%-", ""):gsub("%-$", "") -- remove trailing hyphens, both sides
+	if #slug > MAX_SLUG_LENGTH then
+		slug = slug:sub(1, MAX_SLUG_LENGTH):gsub("%-$", "")
+	end
+	return slug ~= "" and slug or "repo"
+end
+
+---@param path string
+---@return boolean
+local function is_absolute(path)
+	local normalized = normalize_separators(path)
+	return normalized:sub(1, 1) == "/" or normalized:match("^%a:/") ~= nil
+end
+
+---@param ... string
+---@return string
+local function join(...)
+	local parts = {}
+	for _, part in ipairs({ ... }) do
+		local value = normalize_separators(tostring(part or "")):gsub("/+$", "")
+		if value ~= "" then
+			table.insert(parts, value)
+		end
+	end
+	return table.concat(parts, "/")
+end
+
+-- Canonical form for path comparison: symlinks resolved when the path exists, separators
+-- normalized, trailing separators dropped.
+---@param path string
+---@return string
+local function canonical(path)
+	local value = trim(path)
+	local real = vim.uv and vim.uv.fs_realpath and vim.uv.fs_realpath(value) or nil
+	return (normalize_separators(real or value):gsub("/+$", ""))
+end
+
+---@return string
+function M.cache_root()
+	return join(vim.fn.stdpath("cache"), CACHE_SEGMENTS)
+end
+
+-- True only for directories strictly below the cache root. Everything Atlas is allowed to delete by
+-- hand lives there; a user supplied `dir` never qualifies, so a failed removal cannot wipe it.
+---@param dir string
+---@return boolean
+function M.is_cache_path(dir)
+	local prefix = M.cache_root() .. "/"
+	local value = normalize_separators(trim(dir)):gsub("/+$", "")
+	return #value > #prefix and value:sub(1, #prefix) == prefix
+end
+
+---@class AtlasWorktreeContext
+---@field repo_root string
+---@field repo_full_name string|nil
+---@field pr_id string|integer|nil
+---@field head_sha string
+---@field default string|nil Only populated when handed to a user supplied `dir` function.
+
+-- Default location: <cache>/atlas/worktrees/<repo-slug>-<sha>
+---@param ctx AtlasWorktreeContext
+---@return string
+function M.default_dir(ctx)
+	local name = trim(ctx.repo_full_name)
+	if name == "" then
+		name = basename(ctx.repo_root)
+	end
+	-- These paths show up in pickers and statuslines, so prefer the pull request number over a
+	-- hash. A worktree whose head moved is rebuilt by ensure, so the number stays unambiguous.
+	local pr_id = trim(ctx.pr_id)
+	local leaf = pr_id ~= "" and "pr-" .. slugify(pr_id) or trim(ctx.head_sha):sub(1, SHA_LENGTH)
+	if leaf == "" then
+		leaf = "head"
+	end
+	return join(M.cache_root(), slugify(name), leaf)
+end
+
+---@param cfg AtlasPullsDiffLspConfig|nil
+---@return boolean ok
+---@return string|nil err
+function M.validate(cfg)
+	if cfg == nil then
+		return true, nil
+	end
+	if type(cfg) ~= "table" then
+		return false, "diff.lsp must be a table"
+	end
+	if cfg.enabled ~= nil and type(cfg.enabled) ~= "boolean" then
+		return false, "diff.lsp.enabled must be a boolean"
+	end
+	local dir = cfg.dir
+	if dir ~= nil and type(dir) ~= "string" and type(dir) ~= "function" then
+		return false, "diff.lsp.dir must be a string or a function"
+	end
+	if type(dir) == "string" and not is_absolute(dir) then
+		return false, "diff.lsp.dir must be an absolute path"
+	end
+	if cfg.link ~= nil then
+		if type(cfg.link) ~= "table" then
+			return false, "diff.lsp.link must be a list of relative paths"
+		end
+		for _, entry in ipairs(cfg.link) do
+			if type(entry) ~= "string" or trim(entry) == "" then
+				return false, "diff.lsp.link entries must be non-empty strings"
+			end
+			local value = normalize_separators(trim(entry))
+			if is_absolute(value) then
+				return false, string.format("diff.lsp.link entry must be relative: %s", entry)
+			end
+			if value == ".." or value:find("^%.%./") or value:find("/%.%./") or value:find("/%.%.$") then
+				return false, string.format("diff.lsp.link entry must not escape the repository: %s", entry)
+			end
+			if value == ".git" or value:find("^%.git/") then
+				return false, "diff.lsp.link entry must not be .git"
+			end
+		end
+	end
+	return true, nil
+end
+
+-- Resolve where the worktree for `ctx` should live, honouring a user supplied override.
+---@param ctx AtlasWorktreeContext
+---@param cfg AtlasPullsDiffLspConfig|nil
+---@return string|nil dir
+---@return string|nil err
+function M.resolve_dir(ctx, cfg)
+	local ok, err = M.validate(cfg)
+	if not ok then
+		return nil, err
+	end
+
+	local default = M.default_dir(ctx)
+	local override = cfg and cfg.dir or nil
+	if override == nil then
+		return default, nil
+	end
+
+	local resolved
+	if type(override) == "function" then
+		local argument = { default = default }
+		for key, value in pairs(ctx) do
+			argument[key] = value
+		end
+		local called, value = pcall(override, argument)
+		if not called then
+			return nil, "diff.lsp.dir raised an error: " .. tostring(value)
+		end
+		if value == nil or trim(value) == "" then
+			return default, nil
+		end
+		if type(value) ~= "string" then
+			return nil, "diff.lsp.dir must return a string or nil"
+		end
+		resolved = trim(value)
+	else
+		resolved = trim(override)
+	end
+
+	if not is_absolute(resolved) then
+		return nil, string.format("diff.lsp.dir must be an absolute path: %s", resolved)
+	end
+	return (normalize_separators(resolved):gsub("/+$", "")), nil
+end
+
+-- Claims
+
+---@type table<string, { repo_root: string }>
+local claims = {}
+
+---@param dir string
+---@return boolean
+function M.is_claimed(dir)
+	return claims[dir] ~= nil
+end
+
+---@return string[]
+function M.claimed_dirs()
+	local dirs = {}
+	for dir in pairs(claims) do
+		table.insert(dirs, dir)
+	end
+	table.sort(dirs)
+	return dirs
+end
+
+---@param dir string
+function M.release(dir)
+	claims[dir] = nil
+end
+
+-- A worktree is only shared sequentially: while a session holds one, the next session gets its own
+-- suffixed directory. Sessions paint extmarks into these buffers with module level namespaces, so
+-- two sessions sharing one real buffer would overwrite each other's overlays.
+---@param ctx AtlasWorktreeContext
+---@param cfg AtlasPullsDiffLspConfig|nil
+---@return string|nil dir
+---@return string|nil err
+function M.claim(ctx, cfg)
+	local base, err = M.resolve_dir(ctx, cfg)
+	if not base then
+		return nil, err
+	end
+
+	if not M.is_claimed(base) then
+		claims[base] = { repo_root = ctx.repo_root }
+		return base, nil
+	end
+
+	for index = 2, 99 do
+		local candidate = string.format("%s-%d", base, index)
+		if not M.is_claimed(candidate) then
+			claims[candidate] = { repo_root = ctx.repo_root }
+			return candidate, nil
+		end
+	end
+	return nil, "too many active worktrees for " .. base
+end
+
+-- Async helpers
+
+---@param res vim.SystemCompleted
+---@param fallback string
+---@return string
+local function command_error(res, fallback)
+	local message = trim(res.stderr)
+	if message ~= "" then
+		return message
+	end
+
+	return string.format("%s (exit code %d)", fallback, res.code)
+end
+
+-- Paths from `git worktree list --porcelain`, in the order git prints them.
+---@param stdout string|nil
+---@return string[]
+function M.parse_worktree_list(stdout)
+	local paths = {}
+	for line in tostring(stdout or ""):gmatch("[^\r\n]+") do
+		local path = line:match("^worktree%s+(.+)$")
+		if path then
+			table.insert(paths, trim(path))
+		end
+	end
+	return paths
+end
+
+---@param on_done fun(dir: string|nil, err: string|nil)
+local function new_operation(on_done)
+	local op = { cancelled = false, finished = false, handle = nil }
+
+	op.cancel = function()
+		if op.cancelled or op.finished then
+			return
+		end
+		op.cancelled = true
+		if op.handle then
+			pcall(op.handle.cancel)
+			op.handle = nil
+		end
+	end
+
+	---@param dir string|nil
+	---@param err string|nil
+	op.finish = function(dir, err)
+		if op.cancelled or op.finished then
+			return
+		end
+		op.finished = true
+		op.handle = nil
+		on_done(dir, err)
+	end
+
+	---@param args string[]
+	---@param on_exit fun(res: vim.SystemCompleted)
+	op.git = function(args, on_exit)
+		if op.cancelled or op.finished then
+			return
+		end
+		local ok, handle = pcall(core_git.run, args, { text = true }, function(res)
+			if not op.cancelled and not op.finished then
+				on_exit(res)
+			end
+		end)
+		if ok and handle then
+			op.handle = handle
+			return
+		end
+		vim.schedule(function()
+			op.finish(nil, ok and "Failed to start git" or tostring(handle))
+		end)
+	end
+
+	return op
+end
+
+---@param dir string
+---@return boolean
+local function directory_exists(dir)
+	return vim.fn.isdirectory(dir) == 1
+end
+
+-- Recursive delete, restricted to the cache root. Anything else is left alone and reported, since
+-- a user supplied `dir` may point at a directory that was never ours.
+---@param dir string
+---@param reason string
+---@return boolean deleted
+local function delete_owned(dir, reason)
+	if not directory_exists(dir) then
+		return true
+	end
+	if not M.is_cache_path(dir) then
+		logger.logwarn("worktree refusing to delete outside the cache root", { dir = dir, reason = reason })
+		return false
+	end
+	vim.fn.delete(dir, "rf")
+	return true
+end
+
+-- Symlink dependency directories from the main checkout so language servers can resolve them.
+-- Failures are never fatal: a worktree without node_modules still gives useful navigation.
+---@param repo_root string
+---@param dir string
+---@param link string[]|nil
+local function apply_links(repo_root, dir, link)
+	for _, entry in ipairs(link or {}) do
+		local relative = normalize_separators(trim(entry)):gsub("^/+", ""):gsub("/+$", "")
+		local source = join(repo_root, relative)
+		local target = join(dir, relative)
+		if relative ~= "" and (directory_exists(source) or vim.uv.fs_stat(source)) and not vim.uv.fs_lstat(target) then
+			local parent = target:match("^(.*)/[^/]+$")
+			if parent and parent ~= "" then
+				vim.fn.mkdir(parent, "p")
+			end
+			local ok, err = vim.uv.fs_symlink(source, target, { dir = true, junction = true })
+			if not ok then
+				logger.logwarn("worktree.link failed", { source = source, target = target, error = tostring(err) })
+			end
+		end
+	end
+end
+
+---@param repo_root string
+---@param dir string
+---@param on_done fun(err: string|nil)|nil
+---@return { cancel: fun() }|nil
+function M.remove(repo_root, dir, on_done)
+	on_done = on_done or function() end
+	if trim(dir) == "" then
+		on_done(nil)
+		return nil
+	end
+	return core_git.run({ "-C", repo_root, "worktree", "remove", "--force", dir }, { text = true }, function(res)
+		if res.code == 0 then
+			on_done(nil)
+			return
+		end
+		-- The worktree may already be gone or the metadata broken; clean up by hand, but only inside
+		-- the cache root.
+		local error_message = command_error(res, "Failed to remove worktree")
+		local deleted = delete_owned(dir, error_message)
+		core_git.run({ "-C", repo_root, "worktree", "prune" }, { text = true }, function()
+			if deleted then
+				logger.logwarn("worktree.remove fell back to manual delete", { dir = dir, error = error_message })
+			end
+			on_done(nil)
+		end)
+	end)
+end
+
+-- Give up a worktree. The claim is held until the directory is actually gone, so a session that
+-- reopens the same commit meanwhile gets its own directory instead of racing the removal.
+---@param repo_root string
+---@param dir string
+function M.discard(repo_root, dir)
+	if not M.is_claimed(dir) then
+		M.remove(repo_root, dir)
+		return
+	end
+	M.remove(repo_root, dir, function()
+		M.release(dir)
+	end)
+end
+
+-- Remove every claimed worktree synchronously. Called on exit, where an async removal would never
+-- get the chance to run; anything that still slips through is caught by prune on the next open.
+---@param timeout_ms integer|nil
+function M.shutdown(timeout_ms)
+	local timeout = timeout_ms or 2000
+	for dir, info in pairs(claims) do
+		pcall(function()
+			vim.system({ "git", "-C", info.repo_root, "worktree", "remove", "--force", dir }, { text = true })
+				:wait(timeout)
+		end)
+		delete_owned(dir, "shutdown")
+	end
+	claims = {}
+end
+
+-- Best effort cleanup of directories left behind by a crash. Never touches claimed worktrees.
+---@param repo_root string
+function M.prune(repo_root)
+	core_git.run({ "-C", repo_root, "worktree", "prune" }, { text = true }, function() end)
+
+	local root = M.cache_root()
+	if not directory_exists(root) then
+		return
+	end
+	local now = os.time()
+
+	---@param dir string
+	local function remove_if_stale(dir)
+		if M.is_claimed(dir) then
+			return false
+		end
+		local stat = vim.uv.fs_stat(dir)
+		local mtime = stat and stat.mtime and stat.mtime.sec or now
+		if now - mtime <= STALE_SECONDS then
+			return false
+		end
+		logger.loginfo("worktree.prune removing stale worktree", { dir = dir })
+		vim.fn.delete(dir, "rf")
+		return true
+	end
+
+	---@param dir string
+	---@return string[]
+	local function child_directories(dir)
+		local scanner = vim.uv.fs_scandir(dir)
+		local children = {}
+		while scanner do
+			local name, kind = vim.uv.fs_scandir_next(scanner)
+			if not name then
+				break
+			end
+			if kind == "directory" then
+				table.insert(children, join(dir, name))
+			end
+		end
+		return children
+	end
+
+	-- Worktrees live one level below the repository directory, as <repo>/<pr or sha>.
+	for _, repo_dir in ipairs(child_directories(root)) do
+		local children = child_directories(repo_dir)
+		local removed = 0
+		for _, dir in ipairs(children) do
+			if remove_if_stale(dir) then
+				removed = removed + 1
+			end
+		end
+		if #children == 0 or removed == #children then
+			vim.fn.delete(repo_dir, "d")
+		end
+	end
+end
+
+---@class AtlasWorktreeEnsureOptions
+---@field repo_root string
+---@field head_sha string
+---@field dir string
+---@field link string[]|nil
+
+-- Create (or reuse) a detached worktree at `head_sha`. The caller must have fetched the ref first.
+---@param opts AtlasWorktreeEnsureOptions
+---@param on_done fun(dir: string|nil, err: string|nil)
+---@return { cancel: fun() }
+function M.ensure(opts, on_done)
+	local op = new_operation(on_done)
+	local repo_root = trim(opts.repo_root)
+	local head_sha = trim(opts.head_sha)
+	local dir = trim(opts.dir)
+
+	if repo_root == "" or head_sha == "" or dir == "" then
+		vim.schedule(function()
+			op.finish(nil, "Repository path, head revision, and worktree path are required")
+		end)
+		return op
+	end
+
+	local function succeed()
+		apply_links(repo_root, dir, opts.link)
+		op.finish(dir, nil)
+	end
+
+	local function create()
+		local parent = dir:match("^(.*)/[^/]+$")
+		if parent and parent ~= "" then
+			vim.fn.mkdir(parent, "p")
+		end
+		op.git({ "-C", repo_root, "worktree", "add", "--detach", dir, head_sha }, function(res)
+			if res.code ~= 0 then
+				op.finish(nil, command_error(res, "Failed to create worktree"))
+				return
+			end
+			logger.loginfo("worktree.ensure created", { dir = dir, head = head_sha })
+			succeed()
+		end)
+	end
+
+	local function recreate()
+		M.remove(repo_root, dir, function()
+			if op.cancelled or op.finished then
+				return
+			end
+			create()
+		end)
+	end
+
+	-- Reuse an existing worktree only when it already points at the same commit.
+	local function reuse_or_recreate()
+		op.git({ "-C", dir, "rev-parse", "HEAD" }, function(res)
+			local actual = trim(res.stdout)
+			if res.code == 0 and actual ~= "" and actual:sub(1, #head_sha) == head_sha then
+				logger.loginfo("worktree.ensure reused", { dir = dir, head = head_sha })
+				succeed()
+				return
+			end
+			recreate()
+		end)
+	end
+
+	if not directory_exists(dir) then
+		create()
+		return op
+	end
+
+	-- The directory exists. Only a worktree registered to this repository may be reused or rebuilt
+	-- in place. Anything else under the cache root is leftover junk we own; anything else elsewhere
+	-- belongs to the user and is refused rather than deleted.
+	op.git({ "-C", repo_root, "worktree", "list", "--porcelain" }, function(res)
+		if res.code ~= 0 then
+			op.finish(nil, command_error(res, "Failed to list worktrees"))
+			return
+		end
+		local wanted = canonical(dir)
+		for _, path in ipairs(M.parse_worktree_list(res.stdout)) do
+			if canonical(path) == wanted then
+				reuse_or_recreate()
+				return
+			end
+		end
+		if M.is_cache_path(dir) then
+			recreate()
+			return
+		end
+		op.finish(nil, string.format("worktree path exists and is not a worktree of %s: %s", repo_root, dir))
+	end)
+
+	return op
+end
+
+return M

--- a/lua/atlas/health.lua
+++ b/lua/atlas/health.lua
@@ -109,6 +109,18 @@ local function check_pulls()
 	else
 		vim.health.error(string.format("pulls.diff.open_cmd not found: %s", diff_cmd))
 	end
+
+	local lsp = (pulls.diff or {}).lsp or {}
+	local lsp_ok, lsp_err = require("atlas.core.git.worktree").validate(lsp)
+	if not lsp_ok then
+		vim.health.error(string.format("pulls.diff.lsp is invalid: %s", tostring(lsp_err)))
+	elseif not lsp.enabled then
+		vim.health.info("pulls.diff.lsp.enabled is off (diff buffers have no language server)")
+	elseif diff_cmd ~= "AtlasDiff" then
+		vim.health.warn(string.format("pulls.diff.lsp.enabled requires open_cmd AtlasDiff (got %s)", diff_cmd))
+	else
+		vim.health.ok("pulls.diff.lsp enabled")
+	end
 end
 
 local function check_bitbucket()

--- a/lua/atlas/pulls/diff/atlas/init.lua
+++ b/lua/atlas/pulls/diff/atlas/init.lua
@@ -339,8 +339,18 @@ local function navigate_hunk(session, direction)
 end
 
 ---@param session AtlasDiffSession
+local function release_worktree(session)
+	local worktree = session.worktree
+	session.worktree = nil
+	if worktree then
+		pcall(worktree.release)
+	end
+end
+
+---@param session AtlasDiffSession
 local function register_keymaps(session)
-	keymaps.register(session, {
+	---@type AtlasNativeDiffKeymapActions
+	local actions = {
 		close = function()
 			session.close("user_close")
 		end,
@@ -406,7 +416,10 @@ local function register_keymaps(session)
 				comments.add_to_file(session, { path = file.path, old_path = file.old_path }, pending)
 			end
 		end,
-	})
+	}
+	local state = session.viewer_state --[[@as AtlasNativeDiffState]]
+	state.keymap_actions = actions
+	keymaps.register(session, actions)
 end
 
 ---@param session AtlasDiffSession
@@ -580,7 +593,22 @@ function M.detach(session, reason)
 		pcall(vim.cmd, vim.api.nvim_tabpage_get_number(session.tabpage) .. "tabclose")
 	end
 	view.delete_buffers(session)
+	-- Buffers first: they point into the worktree we are about to remove. A reload resolves the head
+	-- again and claims its own worktree, so it releases here too.
+	release_worktree(session)
 	events.emit("AtlasDiffClosed", event_data(session, reason or "viewer_closed"))
 end
+
+-- Worktrees are cheap to recreate but should not pile up in the cache directory. Anything that
+-- still slips through (a crash, a kill) is cleaned up by worktree.prune on the next open.
+vim.api.nvim_create_autocmd("VimLeavePre", {
+	group = vim.api.nvim_create_augroup("AtlasDiffWorktreeShutdown", { clear = true }),
+	callback = function()
+		for _, session in pairs(session_api.all()) do
+			session.worktree = nil
+		end
+		pcall(require("atlas.core.git.worktree").shutdown)
+	end,
+})
 
 return M

--- a/lua/atlas/pulls/diff/atlas/init.lua
+++ b/lua/atlas/pulls/diff/atlas/init.lua
@@ -599,10 +599,85 @@ function M.detach(session, reason)
 	events.emit("AtlasDiffClosed", event_data(session, reason or "viewer_closed"))
 end
 
+local worktree_group = vim.api.nvim_create_augroup("AtlasDiffWorktree", { clear = true })
+
+---@param session AtlasDiffSession
+---@param buf integer
+---@return string|nil path Path relative to the worktree root.
+local function worktree_path(session, buf)
+	local root = session.worktree and session.worktree.root or nil
+	if not root or not vim.api.nvim_buf_is_valid(buf) then
+		return nil
+	end
+	local name = vim.api.nvim_buf_get_name(buf)
+	if name == "" then
+		return nil
+	end
+	local prefix = tostring(root):gsub("/+$", "") .. "/"
+	if name:sub(1, #prefix) ~= prefix then
+		return nil
+	end
+	return name:sub(#prefix + 1)
+end
+
+-- Jumping with gd or references lands on a worktree file. When that file belongs to the pull
+-- request, sync the session to it rather than leaving a plain file sitting in the diff window: the
+-- buffer the jump opened is the same buffer the head side would have loaded anyway. Hooking the
+-- buffer display instead of the LSP handlers keeps every picker and the quickfix list working.
+vim.api.nvim_create_autocmd("BufWinEnter", {
+	group = worktree_group,
+	callback = function(args)
+		local buf = args.buf
+		local session, path
+		for _, candidate in pairs(session_api.all()) do
+			local state = candidate.viewer_state
+			if state and not state.closing then
+				local relative = worktree_path(candidate, buf)
+				if relative then
+					session, path = candidate, relative
+					break
+				end
+			end
+		end
+		if not session then
+			return
+		end
+		view.mark_worktree_buffer(buf)
+
+		local state = session.viewer_state --[[@as AtlasNativeDiffState]]
+		local win = vim.api.nvim_get_current_win()
+		if win ~= state.right.win or buf == state.right.buf then
+			return
+		end
+		local index = file_index(session, path)
+		if not index or index == state.selected_index then
+			return
+		end
+		-- Deferred so the jump has positioned the cursor; that line is kept through the reload.
+		vim.schedule(function()
+			if state.closing or not vim.api.nvim_win_is_valid(win) then
+				return
+			end
+			local line = vim.api.nvim_win_get_cursor(win)[1]
+			select_file(session, index, function()
+				local target = state.right.win
+				if not target or not vim.api.nvim_win_is_valid(target) then
+					return
+				end
+				local count = vim.api.nvim_buf_line_count(state.right.buf)
+				vim.api.nvim_win_set_cursor(target, { math.max(1, math.min(line, count)), 0 })
+				pcall(vim.api.nvim_win_call, target, function()
+					vim.cmd("normal! zvzz")
+				end)
+			end)
+		end)
+	end,
+})
+
 -- Worktrees are cheap to recreate but should not pile up in the cache directory. Anything that
 -- still slips through (a crash, a kill) is cleaned up by worktree.prune on the next open.
 vim.api.nvim_create_autocmd("VimLeavePre", {
-	group = vim.api.nvim_create_augroup("AtlasDiffWorktreeShutdown", { clear = true }),
+	group = worktree_group,
 	callback = function()
 		for _, session in pairs(session_api.all()) do
 			session.worktree = nil

--- a/lua/atlas/pulls/diff/atlas/keymaps.lua
+++ b/lua/atlas/pulls/diff/atlas/keymaps.lua
@@ -7,6 +7,22 @@ local resolver = require("atlas.core.keymaps")
 local review_keymaps = require("atlas.pulls.diff.keymaps")
 local review_panel = require("atlas.pulls.diff.ui.review_panel")
 
+---@class AtlasNativeDiffKeymapActions
+---@field close fun()
+---@field reopen fun()
+---@field refresh_review fun()
+---@field toggle_layout fun()
+---@field toggle_compact fun()
+---@field navigate_hunk fun(direction: 1|-1)
+---@field navigate_file fun(direction: 1|-1)
+---@field navigate_unreviewed_file fun(direction: 1|-1)
+---@field toggle_file_reviewed fun()
+---@field toggle_explorer fun()
+---@field toggle_commits fun()
+---@field select_file fun(index: integer, focus_diff: boolean|nil)
+---@field show_commit fun()
+---@field add_file_comment fun(pending: boolean)
+
 ---@param action AtlasKeymapActionId
 ---@param definition AtlasHelpKeyItem
 ---@return AtlasHelpKeyItem|nil
@@ -38,47 +54,10 @@ local function guard(session, callback)
 	end
 end
 
----@param session AtlasDiffSession
----@param actions {
---- close: fun(),
---- reopen: fun(),
---- refresh_review: fun(),
---- toggle_layout: fun(),
---- toggle_compact: fun(),
---- navigate_hunk: fun(direction: 1|-1),
---- navigate_file: fun(direction: 1|-1),
---- navigate_unreviewed_file: fun(direction: 1|-1),
---- toggle_file_reviewed: fun(),
---- toggle_explorer: fun(),
---- toggle_commits: fun(),
---- select_file: fun(index: integer, focus_diff: boolean|nil),
---- show_commit: fun(),
---- add_file_comment: fun(pending: boolean),
----}
-function M.register(session, actions)
-	local state = session.viewer_state --[[@as AtlasNativeDiffState]]
-	local run = function(callback)
-		return guard(session, callback)
-	end
-	local find_file = run(function()
-		local files = {}
-		for index, file in ipairs(state.files) do
-			files[index] = { index = index, path = file.path }
-		end
-		picker.select({
-			title = "Changed files",
-			items = files,
-			initial_index = state.pending_index or state.selected_index,
-			format_item = function(file)
-				return file.path
-			end,
-			on_select = function(file)
-				if file then
-					actions.select_file(file.index, true)
-				end
-			end,
-		})
-	end)
+---@param actions AtlasNativeDiffKeymapActions
+---@param run fun(callback: fun()): fun()
+---@return AtlasHelpKeyItem[]
+local function content_navigation(actions, run)
 	local navigation = {}
 	add(
 		navigation,
@@ -146,15 +125,50 @@ function M.register(session, actions)
 			opts = { silent = true, nowait = true },
 		})
 	)
-	for _, buf in ipairs({ state.panel.buf, state.commits_panel.buf, state.left.buf, state.right.buf }) do
-		local find_action = buf == state.panel.buf and "pulls.review.explorer.find_file" or "pulls.review.find_file"
-		local find_item = item(find_action, {
-			desc = "Find changed file",
-			index = 7,
-			callback = find_file,
-			opts = { silent = true, nowait = true },
-		})
 
+	return navigation
+end
+
+-- Registered per buffer so the head side can be re-bound when it swaps to a real worktree file.
+---@param session AtlasDiffSession
+---@param buf integer
+---@param actions AtlasNativeDiffKeymapActions
+function M.register_buffer(session, buf, actions)
+	if not vim.api.nvim_buf_is_valid(buf) then
+		return
+	end
+	local state = session.viewer_state --[[@as AtlasNativeDiffState]]
+	local run = function(callback)
+		return guard(session, callback)
+	end
+	local navigation = content_navigation(actions, run)
+	local find_file = run(function()
+		local files = {}
+		for index, file in ipairs(state.files) do
+			files[index] = { index = index, path = file.path }
+		end
+		picker.select({
+			title = "Changed files",
+			items = files,
+			initial_index = state.pending_index or state.selected_index,
+			format_item = function(file)
+				return file.path
+			end,
+			on_select = function(file)
+				if file then
+					actions.select_file(file.index, true)
+				end
+			end,
+		})
+	end)
+	local find_action = buf == state.panel.buf and "pulls.review.explorer.find_file" or "pulls.review.find_file"
+	local find_item = item(find_action, {
+		desc = "Find changed file",
+		index = 7,
+		callback = find_file,
+		opts = { silent = true, nowait = true },
+	})
+	do
 		local general = {}
 		add(
 			general,
@@ -264,6 +278,18 @@ function M.register(session, actions)
 			help.register("Navigation", { find_item }, { index = 120, buffer = buf })
 		end
 	end
+end
+
+---@param session AtlasDiffSession
+---@param actions AtlasNativeDiffKeymapActions
+function M.register(session, actions)
+	local state = session.viewer_state --[[@as AtlasNativeDiffState]]
+	local run = function(callback)
+		return guard(session, callback)
+	end
+	for _, buf in ipairs({ state.panel.buf, state.commits_panel.buf, state.left.buf, state.right.buf }) do
+		M.register_buffer(session, buf, actions)
+	end
 
 	local panel_actions = {}
 	add(
@@ -367,6 +393,24 @@ function M.register(session, actions)
 			state.right.buf,
 		})
 	end
+end
+
+-- Review mappings for a single buffer, for the same reason as `register_buffer`.
+---@param session AtlasDiffSession
+---@param buf integer
+---@param reopen fun()|nil
+function M.register_review_buffer(session, buf, reopen)
+	review_keymaps.register(session, { buffers = { buf }, reopen = reopen })
+end
+
+-- Strip everything this session mapped on a content buffer. Worktree buffers are real files that
+-- outlive the diff, so leaving `q` or `<CR>` bound on them would follow the user around.
+---@param buf integer
+function M.unregister_buffer(buf)
+	if not buf then
+		return
+	end
+	help.remove_buffer(buf)
 end
 
 return M

--- a/lua/atlas/pulls/diff/atlas/renderer.lua
+++ b/lua/atlas/pulls/diff/atlas/renderer.lua
@@ -83,6 +83,14 @@ local function apply_folds(win, ranges, line_count, compact)
 	end)
 end
 
+---@param buf integer
+function M.clear(buf)
+	if vim.api.nvim_buf_is_valid(buf) then
+		vim.api.nvim_buf_clear_namespace(buf, namespace, 0, -1)
+		vim.api.nvim_buf_clear_namespace(buf, inline_namespace, 0, -1)
+	end
+end
+
 ---@param document AtlasDiffDocument
 ---@param right_buf integer
 ---@param comments? table<integer, [string, string][][]>

--- a/lua/atlas/pulls/diff/atlas/view.lua
+++ b/lua/atlas/pulls/diff/atlas/view.lua
@@ -1,8 +1,12 @@
 local M = {}
 
 local commits = require("atlas.pulls.diff.atlas.commits")
+local comments = require("atlas.pulls.diff.ui.comments")
 local diff = require("atlas.ui.components.diff_hunks")
 local explorer = require("atlas.pulls.diff.atlas.explorer")
+local keymaps = require("atlas.pulls.diff.atlas.keymaps")
+local logger = require("atlas.core.logger")
+local notes = require("atlas.pulls.diff.notes")
 local renderer = require("atlas.pulls.diff.atlas.renderer")
 local review_panel = require("atlas.pulls.diff.ui.review_panel")
 local session_api = require("atlas.pulls.diff.session")
@@ -41,6 +45,7 @@ local session_api = require("atlas.pulls.diff.session")
 ---@field job { cancel: fun() }|nil
 ---@field group integer|nil
 ---@field closing boolean
+---@field keymap_actions AtlasNativeDiffKeymapActions|nil Kept so a swapped head buffer can be re-bound.
 
 ---@param name string|nil
 ---@param buftype "nofile"|"nowrite"|nil
@@ -267,15 +272,108 @@ local function focus_first_hunk(session)
 	end
 end
 
+-- Head side buffers
+--
+-- Neovim only attaches language servers to buffers whose buftype is empty, so the new side has to
+-- be a real file. When the session owns a worktree at the PR head we load the file straight from
+-- it; everything else (deleted files, binaries, no worktree) keeps the revision buffer.
+---@param session AtlasDiffSession
+---@param document AtlasDiffDocument
+---@return integer buf
+local function resolve_right_buffer(session, document)
+	local state = session.viewer_state
+	local fallback = state.right.virtual_buf or state.right.buf
+	local worktree = session.worktree
+	local path = document.new.path
+	if not worktree or document.binary or document.status == "deleted" or path == "" then
+		return fallback
+	end
+
+	local full = tostring(worktree.root):gsub("/+$", "") .. "/" .. path:gsub("^/+", "")
+	if vim.fn.filereadable(full) ~= 1 then
+		return fallback
+	end
+
+	local added, buf = pcall(vim.fn.bufadd, full)
+	if not added or not buf or buf == 0 then
+		return fallback
+	end
+	local was_loaded = vim.api.nvim_buf_is_loaded(buf)
+	if not was_loaded and not pcall(vim.fn.bufload, buf) then
+		return fallback
+	end
+
+	-- Hunk highlighting and comment anchoring are line addressed, so a worktree file that does not
+	-- match the blob we diffed (CRLF, symlink, submodule, dirty worktree) has to be rejected.
+	if vim.api.nvim_buf_line_count(buf) ~= #document.new.lines then
+		logger.logwarn("diff.worktree file does not match the diffed revision", { path = full })
+		if not was_loaded then
+			pcall(vim.api.nvim_buf_delete, buf, { force = true })
+		end
+		return fallback
+	end
+
+	state.right.owned_bufs[buf] = true
+	vim.bo[buf].bufhidden = "hide"
+	vim.bo[buf].buflisted = true
+	vim.bo[buf].modifiable = false
+	vim.bo[buf].readonly = true
+	return buf
+end
+
+-- Real worktree buffers outlive the file switch, so every overlay and mapping this session added
+-- has to come off before we move on. Otherwise the user meets them again in a normal edit session.
+---@param session AtlasDiffSession
+---@param buf integer
+local function detach_content_buffer(session, buf)
+	local state = session.viewer_state
+	if buf == state.right.virtual_buf or not vim.api.nvim_buf_is_valid(buf) then
+		return
+	end
+	renderer.clear(buf)
+	notes.clear_buffer(buf)
+	comments.clear_buffer(buf)
+	keymaps.unregister_buffer(buf)
+end
+
+---@param session AtlasDiffSession
+---@param buf integer
+local function attach_content_buffer(session, buf)
+	local state = session.viewer_state
+	if buf == state.right.virtual_buf or not vim.api.nvim_buf_is_valid(buf) then
+		return
+	end
+	local actions = state.keymap_actions
+	if not actions then
+		return
+	end
+	keymaps.register_buffer(session, buf, actions)
+	keymaps.register_review_buffer(session, buf, actions.reopen)
+end
+
 ---@param session AtlasDiffSession
 ---@param document AtlasDiffDocument
 function M.set_document(session, document)
 	local state = session.viewer_state
 	state.document = document
+
+	local previous = state.right.buf
+	local right_buf = resolve_right_buffer(session, document)
+	if right_buf ~= previous then
+		detach_content_buffer(session, previous)
+		state.right.buf = right_buf
+		if state.right.win and vim.api.nvim_win_is_valid(state.right.win) then
+			vim.api.nvim_win_set_buf(state.right.win, right_buf)
+		end
+		attach_content_buffer(session, right_buf)
+	end
+
 	name_content_buffer(session, state.left.buf, session.source.base_revision, document.old.path)
-	name_content_buffer(session, state.right.buf, session.source.head_revision, document.new.path)
 	set_buffer(state.left.buf, document.old.lines, document.old.path)
-	set_buffer(state.right.buf, document.new.lines, document.new.path)
+	if right_buf == state.right.virtual_buf then
+		name_content_buffer(session, right_buf, session.source.head_revision or "WORKTREE", document.new.path)
+		set_buffer(right_buf, document.new.lines, document.new.path)
+	end
 	arrange_content_windows(session)
 	if state.left.win then
 		M.configure_content_window(session, state.left.win)
@@ -514,7 +612,7 @@ function M.create(session, data, options)
 		commits_visible = options.explorer.show_commits and #session.commits > 0,
 		commit_items = {},
 		left = { buf = left_buf, win = nil },
-		right = { buf = right_buf, win = right_win },
+		right = { buf = right_buf, win = right_win, virtual_buf = right_buf, owned_bufs = {} },
 		annotated_paths = {},
 		inline_deleted_lines = true,
 		additions = additions,
@@ -536,8 +634,19 @@ end
 ---@param session AtlasDiffSession
 function M.delete_buffers(session)
 	local state = session.viewer_state
-	for _, buf in ipairs({ state.panel.buf, state.commits_panel.buf, state.left.buf, state.right.buf }) do
-		if vim.api.nvim_buf_is_valid(buf) then
+	local buffers = {
+		state.panel.buf,
+		state.commits_panel.buf,
+		state.left.buf,
+		state.right.buf,
+		state.right.virtual_buf,
+	}
+	-- Worktree buffers point into a directory that is about to be removed.
+	for buf in pairs(state.right.owned_bufs or {}) do
+		buffers[#buffers + 1] = buf
+	end
+	for _, buf in ipairs(buffers) do
+		if buf and vim.api.nvim_buf_is_valid(buf) then
 			pcall(vim.api.nvim_buf_delete, buf, { force = true })
 		end
 	end

--- a/lua/atlas/pulls/diff/atlas/view.lua
+++ b/lua/atlas/pulls/diff/atlas/view.lua
@@ -272,6 +272,19 @@ local function focus_first_hunk(session)
 	end
 end
 
+-- Everything inside a worktree is a throwaway checkout, including files reached by jumping out of
+-- the diff. Keep them read only so edits cannot be lost with the directory, and unlisted so a
+-- review does not add a second entry per file to the buffer list.
+---@param buf integer
+function M.mark_worktree_buffer(buf)
+	if not vim.api.nvim_buf_is_valid(buf) then
+		return
+	end
+	vim.bo[buf].buflisted = false
+	vim.bo[buf].modifiable = false
+	vim.bo[buf].readonly = true
+end
+
 -- Head side buffers
 --
 -- Neovim only attaches language servers to buffers whose buftype is empty, so the new side has to
@@ -315,9 +328,7 @@ local function resolve_right_buffer(session, document)
 
 	state.right.owned_bufs[buf] = true
 	vim.bo[buf].bufhidden = "hide"
-	vim.bo[buf].buflisted = true
-	vim.bo[buf].modifiable = false
-	vim.bo[buf].readonly = true
+	M.mark_worktree_buffer(buf)
 	return buf
 end
 
@@ -641,9 +652,19 @@ function M.delete_buffers(session)
 		state.right.buf,
 		state.right.virtual_buf,
 	}
-	-- Worktree buffers point into a directory that is about to be removed.
+	-- Every buffer under the worktree points into a directory that is about to be removed, including
+	-- files the user reached by jumping out of the diff. Leaving them behind dangles them.
 	for buf in pairs(state.right.owned_bufs or {}) do
 		buffers[#buffers + 1] = buf
+	end
+	local root = session.worktree and session.worktree.root or nil
+	if root then
+		local prefix = tostring(root):gsub("/+$", "") .. "/"
+		for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+			if vim.api.nvim_buf_get_name(buf):sub(1, #prefix) == prefix then
+				buffers[#buffers + 1] = buf
+			end
+		end
 	end
 	for _, buf in ipairs(buffers) do
 		if buf and vim.api.nvim_buf_is_valid(buf) then

--- a/lua/atlas/pulls/diff/init.lua
+++ b/lua/atlas/pulls/diff/init.lua
@@ -48,6 +48,86 @@ local function start_loading(message, context, on_done)
 	return view, requests, finish
 end
 
+---@class AtlasDiffWorktree
+---@field root string
+---@field release fun()
+
+-- A detached worktree at the PR head turns the new side of the diff into real files, which is the
+-- only way a language server will attach (Neovim skips buffers whose buftype is not empty).
+-- Failure is never fatal: the diff falls back to revision buffers without LSP.
+---@param session AtlasDiffSession
+---@param view AtlasLoadingView
+---@param on_done fun(worktree: AtlasDiffWorktree|nil)
+---@return { cancel: fun() }|nil
+local function prepare_worktree(session, view, on_done)
+	local lsp_cfg = (((config.options.pulls or {}).diff or {}).lsp or {})
+	-- if they dont have lsp enabled, just short it
+	if not lsp_cfg.enabled then
+		on_done(nil)
+		return nil
+	end
+
+	local worktree = require("atlas.core.git.worktree")
+	local git_root = session.source.root
+	local head_sha = session.source.head_revision
+	-- No head revision means the new side already is the working tree: real files a language server
+	-- attaches to on its own, and nothing a detached worktree could check out.
+	if not head_sha then
+		on_done(nil)
+		return nil
+	end
+
+	local pr = session.review and session.review.pr or nil
+	---@type AtlasWorktreeContext
+	local context = {
+		repo_root = git_root,
+		repo_full_name = pr and pr.repo_full_name or nil,
+		pr_id = pr and pr.id or nil,
+		head_sha = head_sha,
+	}
+
+	local dir, claim_err = worktree.claim(context, lsp_cfg)
+	if not dir then
+		logger.logwarn("diff.worktree claim failed", { error = tostring(claim_err) })
+		on_done(nil)
+		return nil
+	end
+
+	pcall(worktree.prune, git_root)
+	view:update("Preparing worktree...")
+	local released = false
+	local function release()
+		if released then
+			return
+		end
+		released = true
+		worktree.discard(git_root, dir)
+	end
+
+	local handle = worktree.ensure({
+		repo_root = git_root,
+		head_sha = head_sha,
+		dir = dir,
+		link = lsp_cfg.link,
+	}, function(created, err)
+		if not created then
+			logger.logwarn("diff.worktree unavailable", { dir = dir, error = tostring(err) })
+			released = true
+			worktree.discard(git_root, dir)
+			on_done(nil)
+			return
+		end
+		on_done({ root = created, release = release })
+	end)
+
+	return {
+		cancel = function()
+			pcall(handle.cancel)
+			release()
+		end,
+	}
+end
+
 ---@param command string
 ---@param source AtlasDiffSource
 ---@return string|nil
@@ -70,10 +150,11 @@ end
 
 ---@param command string
 ---@param data { source: AtlasDiffSource, review: AtlasDiffReview|nil, commits: PullsCommit[], warnings: string[] }
+---@param view AtlasLoadingView
 ---@param open_again fun(on_done: fun(err: string|nil))
 ---@param on_done fun(err: string|nil)
 ---@return { cancel: fun() }|nil
-local function open_viewer(command, data, open_again, on_done)
+local function open_viewer(command, data, view, open_again, on_done)
 	local viewer = VIEWERS[command]
 	if not viewer then
 		on_done(open_command(command, data.source))
@@ -87,14 +168,55 @@ local function open_viewer(command, data, open_again, on_done)
 		commits = data.commits,
 		open_again = open_again,
 	})
-	return viewer.open(session, function(err)
+
+	local function finish(err)
 		if err then
 			session_api.detach(session, "open_failed")
 		elseif #data.warnings > 0 then
 			session_api.notify(session, "warn", table.concat(data.warnings, "; "))
 		end
 		on_done(err)
+	end
+
+	-- Only the native viewer reads worktree backed buffers; the others diff revisions themselves.
+	if viewer.id ~= "atlas" or not data.source.head_revision then
+		return viewer.open(session, finish)
+	end
+
+	local cancelled = false
+	local current
+	local request = prepare_worktree(session, view, function(worktree)
+		if cancelled then
+			if worktree then
+				worktree.release()
+			end
+			return
+		end
+		session.worktree = worktree
+		current = viewer.open(session, function(err)
+			-- The viewer releases the worktree when it detaches, so only clean up when it never attached.
+			if err then
+				local claimed = session.worktree
+				session.worktree = nil
+				if claimed then
+					pcall(claimed.release)
+				end
+			end
+			finish(err)
+		end)
 	end)
+
+	return {
+		cancel = function()
+			cancelled = true
+			if request then
+				pcall(request.cancel)
+			end
+			if current then
+				current.cancel()
+			end
+		end,
+	}
 end
 
 ---@param opts { provider: PullsProvider, current_user: PullsUser|nil, root: string|nil }
@@ -181,7 +303,7 @@ function M.open_pr(opts, on_done)
 					return
 				end
 				requests.run(function(done)
-					return open_viewer(command, data, function(reopen_done)
+					return open_viewer(command, data, view, function(reopen_done)
 						M.open_pr({
 							provider = opts.provider,
 							ref = opts.ref,
@@ -212,11 +334,11 @@ function M.open_range(opts, on_done)
 		base_revision = source.base_revision,
 		head_revision = source.head_revision,
 	}
-	local _, requests, finish = start_loading("Preparing diff...", context, on_done)
+	local view, requests, finish = start_loading("Preparing diff...", context, on_done)
 	local data = { source = source, commits = {}, warnings = {} }
 
 	requests.run(function(done)
-		return open_viewer(command, data, function(reopen_done)
+		return open_viewer(command, data, view, function(reopen_done)
 			M.open_range({
 				root = source.root,
 				base = source.base_revision,

--- a/lua/atlas/pulls/diff/notes.lua
+++ b/lua/atlas/pulls/diff/notes.lua
@@ -10,13 +10,24 @@ local virtual_lines = require("atlas.ui.components.virtual_lines")
 
 local namespace = vim.api.nvim_create_namespace("atlas_diff_notes")
 
+---@param buf integer
+local function clear(buf)
+	if vim.api.nvim_buf_is_valid(buf) then
+		vim.api.nvim_buf_clear_namespace(buf, namespace, 0, -1)
+	end
+end
+
 ---@param current AtlasDiffCurrent
 function M.clear(current)
 	for _, side in ipairs({ current.left, current.right }) do
-		if vim.api.nvim_buf_is_valid(side.buf) then
-			vim.api.nvim_buf_clear_namespace(side.buf, namespace, 0, -1)
-		end
+		clear(side.buf)
 	end
+end
+
+-- Clearing a single buffer matters for worktree backed head buffers, which outlive the file switch.
+---@param buf integer
+function M.clear_buffer(buf)
+	clear(buf)
 end
 
 ---@param session AtlasDiffSession

--- a/lua/atlas/pulls/diff/session.lua
+++ b/lua/atlas/pulls/diff/session.lua
@@ -323,6 +323,17 @@ function M.get(tabpage)
 	return sessions[tabpage or vim.api.nvim_get_current_tabpage()]
 end
 
+-- Every attached session, in no particular order. Used by the worktree autocmds, which need to find
+-- the session that owns a buffer without knowing its tabpage.
+---@return AtlasDiffSession[]
+function M.all()
+	local result = {}
+	for _, session in pairs(sessions) do
+		table.insert(result, session)
+	end
+	return result
+end
+
 ---@param session AtlasDiffSession
 ---@param reason string|nil
 function M.detach(session, reason)

--- a/lua/atlas/pulls/diff/session.lua
+++ b/lua/atlas/pulls/diff/session.lua
@@ -21,6 +21,8 @@ local review_progress = { "󰝦", "󰪞", "󰪟", "󰪠", "󰪡", "󰪢", "󰪣"
 ---@class AtlasDiffWindow
 ---@field buf integer
 ---@field win integer|nil
+---@field virtual_buf integer|nil Scratch fallback used when the head side has no real file.
+---@field owned_bufs table<integer, true>|nil Real worktree buffers loaded by this session.
 
 ---@class AtlasDiffLineChange
 ---@field old_start integer
@@ -79,6 +81,7 @@ local review_progress = { "󰝦", "󰪞", "󰪟", "󰪠", "󰪡", "󰪢", "󰪣"
 ---@field review_panel AtlasDiffReviewPanel|nil
 ---@field review_request { cancel: fun() }|nil
 ---@field note_target AtlasNoteTarget|nil
+---@field worktree AtlasDiffWorktree|nil Detached worktree backing the head side, when one was claimed.
 ---@field viewer_state table
 ---@field expanded_threads table<string, boolean>
 ---@field expanded_overlays boolean

--- a/lua/atlas/pulls/diff/ui/comments.lua
+++ b/lua/atlas/pulls/diff/ui/comments.lua
@@ -44,13 +44,24 @@ local function comment_location(comment)
 	return line and (side .. tostring(line)) or ""
 end
 
+---@param buf integer
+local function clear(buf)
+	if vim.api.nvim_buf_is_valid(buf) then
+		vim.api.nvim_buf_clear_namespace(buf, namespace, 0, -1)
+	end
+end
+
 ---@param current AtlasDiffCurrent
 function M.clear(current)
 	for _, side in ipairs({ current.left, current.right }) do
-		if vim.api.nvim_buf_is_valid(side.buf) then
-			vim.api.nvim_buf_clear_namespace(side.buf, namespace, 0, -1)
-		end
+		clear(side.buf)
 	end
+end
+
+-- Clearing a single buffer matters for worktree backed head buffers, which outlive the file switch.
+---@param buf integer
+function M.clear_buffer(buf)
+	clear(buf)
 end
 
 ---@param context AtlasCommentRendererContext

--- a/lua/atlas/ui/popups/help.lua
+++ b/lua/atlas/ui/popups/help.lua
@@ -45,6 +45,7 @@ local function ensure_state(bufnr)
 			keys = {},
 			commands = {},
 			group_opts = {},
+			mapped = {},
 		}
 
 		vim.api.nvim_create_autocmd("BufWipeout", {
@@ -128,6 +129,7 @@ function M.register(group, items, opts)
 		if item.callback then
 			for _, k in ipairs(keys) do
 				vim.keymap.set(mode, k, item.callback, key_opts)
+				table.insert(bstate.mapped, { mode = mode, key = k })
 			end
 		end
 
@@ -179,6 +181,27 @@ function M.register_command(group, items, opts)
 			})
 		end
 	end
+end
+
+-- Drop every mapping and help entry Atlas registered on a buffer. Needed for buffers that outlive
+-- the view that mapped them, such as the worktree files behind a diff's head side.
+---@param bufnr integer
+function M.remove_buffer(bufnr)
+	local bstate = state.buffers[bufnr]
+	if not bstate then
+		return
+	end
+	if vim.api.nvim_buf_is_valid(bufnr) then
+		for _, mapping in ipairs(bstate.mapped or {}) do
+			pcall(vim.keymap.del, mapping.mode, mapping.key, { buffer = bufnr })
+		end
+		for _, commands in pairs(bstate.commands) do
+			for _, entry in ipairs(commands) do
+				pcall(vim.api.nvim_buf_del_user_command, bufnr, entry.name)
+			end
+		end
+	end
+	state.buffers[bufnr] = nil
 end
 
 ---@param group string The name of the group

--- a/spec/worktree_spec.lua
+++ b/spec/worktree_spec.lua
@@ -1,0 +1,460 @@
+local worktree = require("atlas.core.git.worktree")
+local core_git = require("atlas.core.git")
+local logger = require("atlas.core.logger")
+
+---@param overrides table|nil
+---@return AtlasWorktreeContext
+local function context(overrides)
+	local ctx = {
+		repo_root = "/home/dev/code/atlas.nvim",
+		repo_full_name = "emrearmagan/atlas.nvim",
+		head_sha = "abcdef0123456789abcdef0123456789abcdef01",
+	}
+	for key, value in pairs(overrides or {}) do
+		ctx[key] = value
+	end
+	return ctx
+end
+
+-- Scripted git runner: answers each command from `responses`, keyed by the subcommand that follows
+-- `-C <path>`. Records every invocation so specs can assert what ran and what did not.
+---@param responses table<string, { code: integer, stdout: string|nil, stderr: string|nil }>
+---@return { calls: string[][] }
+local function fake_git(responses)
+	local recorder = { calls = {} }
+	core_git.run = function(args, _, on_done)
+		table.insert(recorder.calls, args)
+		local key = args[3] .. (args[4] and (" " .. args[4]) or "")
+		local response = responses[key] or responses[args[3]] or { code = 1, stderr = "unexpected: " .. key }
+		on_done({
+			code = response.code,
+			stdout = response.stdout or "",
+			stderr = response.stderr or "",
+			signal = 0,
+		})
+		return { cancel = function() end }
+	end
+	return recorder
+end
+
+---@param calls string[][]
+---@param subcommand string
+---@return boolean
+local function ran(calls, subcommand)
+	for _, args in ipairs(calls) do
+		if args[3] == "worktree" and args[4] == subcommand then
+			return true
+		end
+	end
+	return false
+end
+
+describe("worktree", function()
+	describe("default_dir", function()
+		it("slugifies the repo name and truncates the sha", function()
+			local dir = worktree.default_dir(context())
+
+			assert.equals(worktree.cache_root() .. "/emrearmagan-atlas-nvim/abcdef012345", dir)
+		end)
+
+		it("prefers the pull request number over the sha", function()
+			local dir = worktree.default_dir(context({ pr_id = 1234 }))
+
+			assert.equals(worktree.cache_root() .. "/emrearmagan-atlas-nvim/pr-1234", dir)
+		end)
+
+		it("falls back to the repo root basename", function()
+			local dir = worktree.default_dir(context({ repo_full_name = nil }))
+
+			assert.is_truthy(dir:find("atlas-nvim/abcdef012345", 1, true))
+		end)
+
+		it("ignores trailing separators on the repo root", function()
+			local dir = worktree.default_dir(context({ repo_full_name = "", repo_root = "/home/dev/code/atlas.nvim/" }))
+
+			assert.is_truthy(dir:find("atlas-nvim/abcdef012345", 1, true))
+		end)
+
+		it("gives different commits different directories", function()
+			local first = worktree.default_dir(context())
+			local second = worktree.default_dir(context({ head_sha = "0123456789abcdef0123456789abcdef01234567" }))
+
+			assert.are_not.equals(first, second)
+		end)
+
+		it("gives different pull requests different directories", function()
+			local first = worktree.default_dir(context({ pr_id = 1 }))
+			local second = worktree.default_dir(context({ pr_id = 2 }))
+
+			assert.are_not.equals(first, second)
+		end)
+	end)
+
+	describe("resolve_dir", function()
+		it("returns the default when no override is configured", function()
+			local ctx = context()
+
+			assert.equals(worktree.default_dir(ctx), worktree.resolve_dir(ctx, nil))
+			assert.equals(worktree.default_dir(ctx), worktree.resolve_dir(ctx, { enabled = true }))
+		end)
+
+		it("accepts an absolute string override", function()
+			local dir = worktree.resolve_dir(context(), { dir = "/var/tmp/review" })
+
+			assert.equals("/var/tmp/review", dir)
+		end)
+
+		it("strips trailing separators from an override", function()
+			local dir = worktree.resolve_dir(context(), { dir = "/var/tmp/review/" })
+
+			assert.equals("/var/tmp/review", dir)
+		end)
+
+		it("rejects a relative string override", function()
+			local dir, err = worktree.resolve_dir(context(), { dir = "review" })
+
+			assert.is_nil(dir)
+			assert.is_truthy(err)
+		end)
+
+		it("calls a function override with the context and the default", function()
+			local seen
+			local dir = worktree.resolve_dir(context(), {
+				dir = function(ctx)
+					seen = ctx
+					return "/var/tmp/" .. ctx.head_sha:sub(1, 7)
+				end,
+			})
+
+			assert.equals("/var/tmp/abcdef0", dir)
+			assert.equals("emrearmagan/atlas.nvim", seen.repo_full_name)
+			assert.equals("/home/dev/code/atlas.nvim", seen.repo_root)
+			assert.equals(worktree.default_dir(context()), seen.default)
+		end)
+
+		it("falls back to the default when the function returns nil or empty", function()
+			local ctx = context()
+
+			assert.equals(
+				worktree.default_dir(ctx),
+				worktree.resolve_dir(ctx, {
+					dir = function()
+						return nil
+					end,
+				})
+			)
+			assert.equals(
+				worktree.default_dir(ctx),
+				worktree.resolve_dir(ctx, {
+					dir = function()
+						return ""
+					end,
+				})
+			)
+		end)
+
+		it("reports an error when the function raises", function()
+			local dir, err = worktree.resolve_dir(context(), {
+				dir = function()
+					error("boom")
+				end,
+			})
+
+			assert.is_nil(dir)
+			assert.is_truthy(err and err:find("boom", 1, true))
+		end)
+
+		it("rejects a non-string return value", function()
+			local dir, err = worktree.resolve_dir(context(), {
+				dir = function()
+					return 42
+				end,
+			})
+
+			assert.is_nil(dir)
+			assert.is_truthy(err)
+		end)
+	end)
+
+	describe("validate", function()
+		it("accepts an absent or empty config", function()
+			assert.is_true(worktree.validate(nil))
+			assert.is_true(worktree.validate({}))
+		end)
+
+		it("accepts a well formed config", function()
+			assert.is_true(worktree.validate({
+				enabled = true,
+				dir = "/var/tmp/review",
+				link = { "node_modules", ".venv", "packages/app/node_modules" },
+			}))
+		end)
+
+		it("rejects a non-boolean enabled", function()
+			assert.is_false(worktree.validate({ enabled = "yes" }))
+		end)
+
+		it("rejects a dir that is neither string nor function", function()
+			assert.is_false(worktree.validate({ dir = 42 }))
+		end)
+
+		it("rejects a relative dir string", function()
+			assert.is_false(worktree.validate({ dir = "review" }))
+		end)
+
+		it("rejects link entries that are not strings", function()
+			assert.is_false(worktree.validate({ link = { 42 } }))
+			assert.is_false(worktree.validate({ link = { "" } }))
+		end)
+
+		it("rejects absolute link entries", function()
+			assert.is_false(worktree.validate({ link = { "/etc" } }))
+		end)
+
+		it("rejects link entries that escape the repository", function()
+			assert.is_false(worktree.validate({ link = { ".." } }))
+			assert.is_false(worktree.validate({ link = { "../secrets" } }))
+			assert.is_false(worktree.validate({ link = { "packages/../../secrets" } }))
+			assert.is_false(worktree.validate({ link = { "packages/.." } }))
+		end)
+
+		it("rejects linking the git directory", function()
+			assert.is_false(worktree.validate({ link = { ".git" } }))
+			assert.is_false(worktree.validate({ link = { ".git/hooks" } }))
+		end)
+	end)
+
+	describe("claim", function()
+		before_each(function()
+			for _, dir in ipairs(worktree.claimed_dirs()) do
+				worktree.release(dir)
+			end
+		end)
+
+		it("hands out the resolved directory when it is free", function()
+			local ctx = context()
+			local dir = worktree.claim(ctx, nil)
+
+			assert.equals(worktree.default_dir(ctx), dir)
+			assert.is_true(worktree.is_claimed(dir))
+		end)
+
+		it("suffixes the directory while another session holds it", function()
+			local ctx = context()
+			local first = worktree.claim(ctx, nil)
+			local second = worktree.claim(ctx, nil)
+
+			assert.are_not.equals(first, second)
+			assert.equals(first .. "-2", second)
+		end)
+
+		it("reuses a released directory", function()
+			local ctx = context()
+			local first = worktree.claim(ctx, nil)
+			worktree.release(first)
+			local second = worktree.claim(ctx, nil)
+
+			assert.equals(first, second)
+			assert.is_false(worktree.is_claimed(first .. "-2"))
+		end)
+
+		it("propagates resolution errors", function()
+			local dir, err = worktree.claim(context(), { dir = "relative" })
+
+			assert.is_nil(dir)
+			assert.is_truthy(err)
+		end)
+	end)
+
+	describe("is_cache_path", function()
+		it("accepts directories below the cache root", function()
+			assert.is_true(worktree.is_cache_path(worktree.cache_root() .. "/repo/pr-1"))
+			assert.is_true(worktree.is_cache_path(worktree.cache_root() .. "/repo/pr-1/"))
+		end)
+
+		it("rejects the cache root itself", function()
+			assert.is_false(worktree.is_cache_path(worktree.cache_root()))
+			assert.is_false(worktree.is_cache_path(worktree.cache_root() .. "/"))
+		end)
+
+		it("rejects paths outside the cache root", function()
+			assert.is_false(worktree.is_cache_path("/home/dev/reviews"))
+			assert.is_false(worktree.is_cache_path(worktree.cache_root() .. "-other/repo"))
+			assert.is_false(worktree.is_cache_path(""))
+		end)
+	end)
+
+	describe("parse_worktree_list", function()
+		it("returns every worktree path from porcelain output", function()
+			local paths = worktree.parse_worktree_list(table.concat({
+				"worktree /home/dev/code/atlas.nvim",
+				"HEAD 0123456789abcdef0123456789abcdef01234567",
+				"branch refs/heads/main",
+				"",
+				"worktree /tmp/atlas/worktrees/repo/pr-1",
+				"HEAD abcdef0123456789abcdef0123456789abcdef01",
+				"detached",
+				"",
+			}, "\n"))
+
+			assert.same({ "/home/dev/code/atlas.nvim", "/tmp/atlas/worktrees/repo/pr-1" }, paths)
+		end)
+
+		it("handles empty output", function()
+			assert.same({}, worktree.parse_worktree_list(""))
+			assert.same({}, worktree.parse_worktree_list(nil))
+		end)
+	end)
+
+	describe("remove and ensure on existing directories", function()
+		local original_run = core_git.run
+		local original_fn = vim.fn
+		local original_uv = vim.uv
+		local original_logwarn = logger.logwarn
+		local original_loginfo = logger.loginfo
+		local deleted
+		local warnings
+
+		before_each(function()
+			deleted = {}
+			warnings = {}
+			vim.fn = setmetatable({
+				isdirectory = function()
+					return 1
+				end,
+				mkdir = function() end,
+				delete = function(path)
+					table.insert(deleted, path)
+					return 0
+				end,
+			}, { __index = original_fn })
+			vim.uv = setmetatable({
+				fs_realpath = function(path)
+					return path
+				end,
+			}, { __index = original_uv or {} })
+			logger.logwarn = function(message)
+				table.insert(warnings, message)
+			end
+			logger.loginfo = function() end
+		end)
+
+		after_each(function()
+			core_git.run = original_run
+			vim.fn = original_fn
+			vim.uv = original_uv
+			logger.logwarn = original_logwarn
+			logger.loginfo = original_loginfo
+		end)
+
+		it("remove deletes by hand only below the cache root", function()
+			local inside = worktree.cache_root() .. "/repo/pr-1"
+			local outside = "/home/dev/reviews"
+			fake_git({
+				["worktree remove"] = { code = 128, stderr = "not a working tree" },
+				["worktree prune"] = { code = 0 },
+			})
+
+			worktree.remove("/home/dev/code/atlas.nvim", inside)
+			worktree.remove("/home/dev/code/atlas.nvim", outside)
+
+			assert.same({ inside }, deleted)
+		end)
+
+		it("ensure refuses an existing directory that is not a worktree of the repository", function()
+			local calls = fake_git({
+				["worktree list"] = {
+					code = 0,
+					stdout = "worktree /home/dev/code/atlas.nvim\nHEAD 0123\nbranch refs/heads/main\n\n",
+				},
+			})
+			local result, err
+
+			worktree.ensure({
+				repo_root = "/home/dev/code/atlas.nvim",
+				head_sha = "abcdef0123456789abcdef0123456789abcdef01",
+				dir = "/home/dev/reviews",
+			}, function(dir, ensure_err)
+				result, err = dir, ensure_err
+			end)
+
+			assert.is_nil(result)
+			assert.is_truthy(err and err:find("not a worktree", 1, true))
+			assert.same({}, deleted)
+			assert.is_false(ran(calls.calls, "add"))
+			assert.is_false(ran(calls.calls, "remove"))
+		end)
+
+		it("ensure rebuilds an unregistered directory below the cache root", function()
+			local dir = worktree.cache_root() .. "/repo/pr-1"
+			local calls = fake_git({
+				["worktree list"] = { code = 0, stdout = "worktree /home/dev/code/atlas.nvim\n\n" },
+				["worktree remove"] = { code = 128, stderr = "not a working tree" },
+				["worktree prune"] = { code = 0 },
+				["worktree add"] = { code = 0 },
+			})
+			local result
+
+			worktree.ensure({
+				repo_root = "/home/dev/code/atlas.nvim",
+				head_sha = "abcdef0123456789abcdef0123456789abcdef01",
+				dir = dir,
+			}, function(created)
+				result = created
+			end)
+
+			assert.equals(dir, result)
+			assert.same({ dir }, deleted)
+			assert.is_true(ran(calls.calls, "add"))
+		end)
+
+		it("ensure reuses a registered worktree at the same head", function()
+			local dir = "/home/dev/reviews"
+			local calls = fake_git({
+				["worktree list"] = {
+					code = 0,
+					stdout = "worktree /home/dev/code/atlas.nvim\n\nworktree " .. dir .. "\ndetached\n\n",
+				},
+				["rev-parse"] = { code = 0, stdout = "abcdef0123456789abcdef0123456789abcdef01\n" },
+			})
+			local result
+
+			worktree.ensure({
+				repo_root = "/home/dev/code/atlas.nvim",
+				head_sha = "abcdef0123456789abcdef0123456789abcdef01",
+				dir = dir,
+			}, function(created)
+				result = created
+			end)
+
+			assert.equals(dir, result)
+			assert.same({}, deleted)
+			assert.is_false(ran(calls.calls, "add"))
+			assert.is_false(ran(calls.calls, "remove"))
+		end)
+
+		it("ensure recreates a registered worktree at a different head", function()
+			local dir = "/home/dev/reviews"
+			local calls = fake_git({
+				["worktree list"] = { code = 0, stdout = "worktree " .. dir .. "\ndetached\n\n" },
+				["rev-parse"] = { code = 0, stdout = "0123456789abcdef0123456789abcdef01234567\n" },
+				["worktree remove"] = { code = 0 },
+				["worktree add"] = { code = 0 },
+			})
+			local result
+
+			worktree.ensure({
+				repo_root = "/home/dev/code/atlas.nvim",
+				head_sha = "abcdef0123456789abcdef0123456789abcdef01",
+				dir = dir,
+			}, function(created)
+				result = created
+			end)
+
+			assert.equals(dir, result)
+			assert.same({}, deleted)
+			assert.is_true(ran(calls.calls, "remove"))
+			assert.is_true(ran(calls.calls, "add"))
+		end)
+	end)
+end)


### PR DESCRIPTION
<img width="1968" height="829" alt="image" src="https://github.com/user-attachments/assets/683d957b-1796-4ca6-8443-6e9f543ad4e9" />

https://github.com/user-attachments/assets/13fbe0a7-798f-4c86-9981-19f9e4768349

<img width="2175" height="496" alt="image" src="https://github.com/user-attachments/assets/59bff9fc-0f1e-48a8-b60a-6975c73da57b" />

This was freaking hard, and I had AI help me through the way. I sort of modeled this after what i do in `haunt.nvim`. Feel free to challenge any decisions that I made. 

Here is a couple of things that might aid review:
- lsp is an _opt in_ feature. Not opt-out
- when a diff opens, Atlas claims a directory under `stdpath("cache")/atlas/worktrees/<repo>/pr-<id>`, runs `git worktree add --detach` at the head sha, and symlinks any `pulls.diff.lsp.link` directories from the checkout so servers can resolve dependencies
- `BufWinEnter` hook syncs the session when an LSP jump lands on a worktree file in the diff window, so `gd` stays inside the review. Hooking buffer display instead of LSP handlers keeps every picker and the quickfix list working.
- nvim only attaches language servers to buffers with an empty buftype, so both sides of a review diff had no `gd`, hover, or references. With `pulls.diff.lsp.enabled`, `AtlasDiff` backs the new side with real files from a detached worktree at the PR head. The old side stays a revision buffer, but both are read only
- cleanup happend on `VimLeavePre`, and any failure to do so will be auto pruned after 7 days with `prune`
 

not so great things:
- Claims are per process. Two nvim instances on the same PR share one directory, and the first close removes it under the other. we could fix this with a lock file or something, but figured this is good enough for now
- i have not tested this on windows at all!

to try it out: 
``` lua
pulls = {
  diff = {
    lsp = {
      enabled = true,
      link = { "node_modules", ".venv" }, -- relative to the repo root
    },
  },
}
```